### PR TITLE
Run 3: implement targeting engine

### DIFF
--- a/minmmo/package-lock.json
+++ b/minmmo/package-lock.json
@@ -19,7 +19,8 @@
         "@types/react-dom": "^18.2.7",
         "@vitejs/plugin-react": "^4.2.0",
         "typescript": "^5.4.5",
-        "vite": "^5.2.0"
+        "vite": "^5.2.0",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1105,6 +1106,23 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1171,6 +1189,131 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.6.tgz",
@@ -1215,6 +1358,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001743",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
@@ -1235,6 +1388,33 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1268,12 +1448,29 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.222",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.222.tgz",
       "integrity": "sha512-gA7psSwSwQRE60CEoLz6JBCQPIxNeuzB2nL8vE03GK/OHxlvykbLyeiumQy1iH5C2f3YbRAZpGCMT12a/9ih9w==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1324,11 +1521,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1399,6 +1634,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1407,6 +1649,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/ms": {
@@ -1442,6 +1694,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/phaser": {
       "version": "3.90.0",
       "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.90.0.tgz",
@@ -1457,6 +1726,19 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -1583,6 +1865,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1591,6 +1880,101 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -1703,6 +2087,119 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/minmmo/package.json
+++ b/minmmo/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "phaser": "^3.90.0",
@@ -20,6 +21,7 @@
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.2.0",
     "typescript": "^5.4.5",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/minmmo/src/config/store.ts
+++ b/minmmo/src/config/store.ts
@@ -1,58 +1,58 @@
+import type { GameConfig } from './schema';
+import { validateAndRepair } from '@content/validate';
 
-import { DEFAULTS } from './defaults'
-import type { GameConfig } from './schema'
+const KEY = 'minmmo:config';
+const storage: Storage | undefined = typeof localStorage === 'undefined' ? undefined : localStorage;
+let current: GameConfig = validateAndRepair({});
+const subs = new Set<(cfg: GameConfig) => void>();
 
-const KEY = 'minmmo:config'
-let current: GameConfig = DEFAULTS
-const subs = new Set<(cfg: GameConfig)=>void>()
-
-function deepMerge<T>(base: T, patch: Partial<T>): T {
-  if (Array.isArray(base)) return (patch as any) ?? base as any
-  if (typeof base === 'object' && base) {
-    const out: any = { ...base }
-    for (const k of Object.keys(patch || {})) {
-      const pv: any = (patch as any)[k]
-      const bv: any = (base as any)[k]
-      out[k] = (bv && typeof bv === 'object' && !Array.isArray(bv)) ? deepMerge(bv, pv || {}) : (pv ?? bv)
-    }
-    return out
+function write(cfg: GameConfig) {
+  current = cfg;
+  if (storage) {
+    storage.setItem(KEY, JSON.stringify(cfg));
   }
-  return (patch as any) ?? base
+  for (const fn of subs) fn(current);
 }
 
 export function load(): GameConfig {
   try {
-    const raw = localStorage.getItem(KEY)
-    if (!raw) {
-      current = DEFAULTS
-    } else {
-      const parsed = JSON.parse(raw)
-      current = deepMerge(DEFAULTS, parsed)
+    if (!storage) {
+      current = validateAndRepair({});
+      return current;
     }
+    const raw = storage.getItem(KEY);
+    const parsed = raw ? JSON.parse(raw) : {};
+    const repaired = validateAndRepair(parsed);
+    current = repaired;
+    storage.setItem(KEY, JSON.stringify(repaired));
   } catch {
-    current = DEFAULTS
+    const repaired = validateAndRepair({});
+    current = repaired;
+    if (storage) {
+      storage.setItem(KEY, JSON.stringify(repaired));
+    }
   }
-  return current
+  return current;
 }
 
 export function save(cfg: GameConfig) {
-  current = deepMerge(DEFAULTS, cfg)
-  localStorage.setItem(KEY, JSON.stringify(current))
-  for (const fn of subs) fn(current)
+  const repaired = validateAndRepair(cfg);
+  write(repaired);
 }
 
 export function exportConfig(): string {
-  return JSON.stringify(current, null, 2)
+  return JSON.stringify(current, null, 2);
 }
 
 export function importConfig(json: string) {
-  const parsed = JSON.parse(json)
-  save(parsed)
+  const parsed = JSON.parse(json);
+  const repaired = validateAndRepair(parsed);
+  write(repaired);
 }
 
-export function subscribe(fn: (cfg: GameConfig)=>void) {
-  subs.add(fn)
-  return () => subs.delete(fn)
+export function subscribe(fn: (cfg: GameConfig) => void) {
+  subs.add(fn);
+  return () => subs.delete(fn);
 }
 
-export const CONFIG = () => current
+export const CONFIG = () => current;

--- a/minmmo/src/content/adapters.ts
+++ b/minmmo/src/content/adapters.ts
@@ -1,1 +1,671 @@
-// TODO: implement adapters to compile config defs into runtime actions/entities
+import type {
+  ActionBase,
+  Cost,
+  Effect,
+  Filter,
+  GameConfig,
+  ItemDef,
+  SkillDef,
+  StackRule,
+  StatusDef,
+  TargetSelector,
+  ValueType,
+} from '@config/schema';
+import type { Actor } from '@engine/battle/types';
+
+export type EnemyFactory = (level: number) => Actor;
+
+type AnyRecord<T> = Record<string, T>;
+
+type Assoc = 'left' | 'right';
+
+export type FormulaContext = Record<string, unknown>;
+
+export type ValueResolver = (user: Actor, target: Actor, ctx: FormulaContext) => number;
+
+interface OperatorConfig {
+  precedence: number;
+  assoc: Assoc;
+  args: number;
+  apply: (...args: number[]) => number;
+}
+
+interface FunctionConfig {
+  arity: number;
+  apply: (...args: number[]) => number;
+}
+
+interface TokenBase {
+  type: string;
+}
+
+interface NumberToken extends TokenBase {
+  type: 'number';
+  value: number;
+}
+
+interface IdentifierToken extends TokenBase {
+  type: 'identifier';
+  value: string;
+}
+
+interface OperatorToken extends TokenBase {
+  type: 'operator';
+  value: keyof typeof OPERATORS;
+}
+
+interface FunctionToken extends TokenBase {
+  type: 'function';
+  name: keyof typeof FUNCTIONS;
+}
+
+interface FunctionRpnToken extends TokenBase {
+  type: 'function-rpn';
+  name: keyof typeof FUNCTIONS;
+}
+
+interface ParenToken extends TokenBase {
+  type: 'paren';
+  value: '(' | ')';
+}
+
+interface CommaToken extends TokenBase {
+  type: 'comma';
+}
+
+type Token =
+  | NumberToken
+  | IdentifierToken
+  | OperatorToken
+  | FunctionToken
+  | FunctionRpnToken
+  | ParenToken
+  | CommaToken;
+
+export interface RuntimeCost {
+  sta: number;
+  mp: number;
+  item?: { id: string; qty: number };
+  cooldown: number;
+  charges?: number;
+}
+
+export interface RuntimeTargetSelector extends TargetSelector {
+  includeDead: boolean;
+  condition?: Filter;
+}
+
+export interface RuntimeValue {
+  kind: ValueType;
+  resolve: ValueResolver;
+  rawAmount?: number;
+  rawPercent?: number;
+  expr?: string;
+  min?: number;
+  max?: number;
+}
+
+export interface RuntimeEffect
+  extends Omit<Effect, 'valueType' | 'amount' | 'percent' | 'formula' | 'selector'> {
+  selector?: RuntimeTargetSelector;
+  value: RuntimeValue;
+}
+
+export interface RuntimeActionBase
+  extends Omit<ActionBase, 'targeting' | 'effects' | 'costs' | 'canUse'> {
+  targeting: RuntimeTargetSelector;
+  effects: RuntimeEffect[];
+  costs: RuntimeCost;
+  canUse?: Filter;
+}
+
+export interface RuntimeSkill extends RuntimeActionBase {
+  type: 'skill';
+}
+
+export interface RuntimeItem extends RuntimeActionBase {
+  type: 'item';
+  consumable: boolean;
+}
+
+export interface RuntimeStatusTemplate extends Omit<StatusDef, 'hooks'> {
+  stackRule: StackRule;
+  maxStacks: number;
+  durationTurns: number | null;
+  tags: string[];
+  modifiers: StatusDef['modifiers'];
+  hooks: {
+    onApply: RuntimeEffect[];
+    onTurnStart: RuntimeEffect[];
+    onTurnEnd: RuntimeEffect[];
+    onDealDamage: RuntimeEffect[];
+    onTakeDamage: RuntimeEffect[];
+    onExpire: RuntimeEffect[];
+  };
+}
+
+interface RuntimeActionContext<T extends SkillDef | ItemDef> {
+  id: string;
+  def: T;
+  scope: string;
+}
+
+const OPERATORS: Record<string, OperatorConfig> = {
+  '+': { precedence: 1, assoc: 'left', args: 2, apply: (a, b) => a + b },
+  '-': { precedence: 1, assoc: 'left', args: 2, apply: (a, b) => a - b },
+  '*': { precedence: 2, assoc: 'left', args: 2, apply: (a, b) => a * b },
+  '/': { precedence: 2, assoc: 'left', args: 2, apply: (a, b) => a / b },
+  '%': { precedence: 2, assoc: 'left', args: 2, apply: (a, b) => a % b },
+  '^': { precedence: 3, assoc: 'right', args: 2, apply: (a, b) => Math.pow(a, b) },
+  neg: { precedence: 4, assoc: 'right', args: 1, apply: (a) => -a },
+};
+
+const FUNCTIONS: Record<string, FunctionConfig> = {
+  min: { arity: 2, apply: (a, b) => Math.min(a, b) },
+  max: { arity: 2, apply: (a, b) => Math.max(a, b) },
+  floor: { arity: 1, apply: (a) => Math.floor(a) },
+  ceil: { arity: 1, apply: (a) => Math.ceil(a) },
+  abs: { arity: 1, apply: (a) => Math.abs(a) },
+  pow: { arity: 2, apply: (a, b) => Math.pow(a, b) },
+  clamp: { arity: 3, apply: (v, min, max) => Math.min(Math.max(v, min), max) },
+  round: { arity: 1, apply: (a) => Math.round(a) },
+  sqrt: { arity: 1, apply: (a) => Math.sqrt(a) },
+};
+
+function deepClone<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((entry) => deepClone(entry)) as unknown as T;
+  }
+  if (value && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      result[key] = deepClone(entry);
+    }
+    return result as T;
+  }
+  return value;
+}
+
+function normalizeSelector(selector?: TargetSelector): RuntimeTargetSelector {
+  const base: TargetSelector = selector
+    ? deepClone(selector)
+    : { side: 'enemy', mode: 'single', count: 1 };
+  return {
+    ...base,
+    count:
+      base.count ?? (base.mode === 'random' ? 1 : base.mode === 'single' ? 1 : base.count),
+    includeDead: Boolean(base.includeDead),
+    condition: base.condition ? deepClone(base.condition) : undefined,
+  };
+}
+
+function normalizeCost(costs?: Cost): RuntimeCost {
+  const src = costs ?? {};
+  return {
+    sta: src.sta ?? 0,
+    mp: src.mp ?? 0,
+    item: src.item ? { id: src.item.id, qty: src.item.qty ?? 1 } : undefined,
+    cooldown: src.cooldown ?? 0,
+    charges: src.charges ?? undefined,
+  };
+}
+
+function compileAction<T extends SkillDef | ItemDef>(context: RuntimeActionContext<T>): T extends SkillDef
+  ? RuntimeSkill
+  : RuntimeItem {
+  const { id, def, scope } = context;
+  const targeting = normalizeSelector(def.targeting);
+  const effects = compileEffects(def.effects ?? [], `${scope}.effects`);
+  const costs = normalizeCost(def.costs);
+  const canUse = def.canUse ? deepClone(def.canUse) : undefined;
+
+  const base: RuntimeActionBase = {
+    id,
+    name: def.name ?? id,
+    desc: def.desc,
+    element: def.element,
+    targeting,
+    effects,
+    costs,
+    canUse,
+    aiWeight: def.aiWeight ?? 1,
+  };
+
+  if (def.type === 'item') {
+    const item: RuntimeItem = {
+      ...base,
+      type: 'item',
+      consumable: def.consumable ?? true,
+    };
+    return item as unknown as T extends SkillDef ? RuntimeSkill : RuntimeItem;
+  }
+
+  const skill: RuntimeSkill = {
+    ...base,
+    type: 'skill',
+  };
+  return skill as unknown as T extends SkillDef ? RuntimeSkill : RuntimeItem;
+}
+
+function compileEffects(effects: Effect[], scope: string): RuntimeEffect[] {
+  return effects.map((effect, index) => compileEffect(effect, `${scope}[${index}]`));
+}
+
+function compileEffect(effect: Effect, scope: string): RuntimeEffect {
+  const selector = effect.selector ? normalizeSelector(effect.selector) : undefined;
+  const value = compileValue(effect, scope);
+  return {
+    kind: effect.kind,
+    element: effect.element,
+    canMiss: effect.canMiss ?? false,
+    canCrit: effect.canCrit ?? false,
+    resource: effect.resource,
+    stat: effect.stat,
+    statusId: effect.statusId,
+    statusTurns: effect.statusTurns,
+    cleanseTags: effect.cleanseTags ? [...effect.cleanseTags] : undefined,
+    shieldId: effect.shieldId,
+    onlyIf: effect.onlyIf ? deepClone(effect.onlyIf) : undefined,
+    selector,
+    value,
+  };
+}
+
+function compileValue(effect: Effect, scope: string): RuntimeValue {
+  const kind: ValueType = effect.valueType ?? (effect.percent != null ? 'percent' : 'flat');
+  const min = effect.min ?? undefined;
+  const max = effect.max ?? undefined;
+
+  const applyClamp = (resolver: ValueResolver): ValueResolver => {
+    return (user, target, ctx) => {
+      const raw = resolver(user, target, ctx);
+      const lower = min ?? -Infinity;
+      const upper = max ?? Infinity;
+      const clamped = Math.min(Math.max(raw, lower), upper);
+      return Number.isFinite(clamped) ? clamped : 0;
+    };
+  };
+
+  if (kind === 'formula') {
+    const expr = effect.formula?.expr ?? '0';
+    const resolver = compileFormula(expr, scope);
+    return {
+      kind,
+      resolve: applyClamp(resolver),
+      expr,
+      min,
+      max,
+    };
+  }
+
+  if (kind === 'percent') {
+    const percent = effect.percent ?? 0;
+    const resolver: ValueResolver = () => percent / 100;
+    return {
+      kind,
+      resolve: applyClamp(resolver),
+      rawPercent: percent,
+      min,
+      max,
+    };
+  }
+
+  const amount = effect.amount ?? 0;
+  const resolver: ValueResolver = () => amount;
+  return {
+    kind: 'flat',
+    resolve: applyClamp(resolver),
+    rawAmount: amount,
+    min,
+    max,
+  };
+}
+
+function compileFormula(expr: string, scope: string): ValueResolver {
+  const tokens = tokenize(expr, scope);
+  const rpn = toRpn(tokens, scope);
+  return (user, target, ctx) => {
+    const stack: number[] = [];
+    const push = (value: number) => {
+      if (!Number.isFinite(value)) {
+        throw new Error(`Formula in ${scope} evaluated to a non-finite number`);
+      }
+      stack.push(value);
+    };
+
+    for (const token of rpn) {
+      switch (token.type) {
+        case 'number':
+          push(token.value);
+          break;
+        case 'identifier':
+          push(resolveIdentifier(token.value, user, target, ctx, scope));
+          break;
+        case 'operator': {
+          const op = OPERATORS[token.value];
+          if (stack.length < op.args) {
+            throw new Error(`Operator ${token.value} in ${scope} is missing operands`);
+          }
+          const args = stack.splice(stack.length - op.args, op.args);
+          const result = op.apply(...args);
+          push(result);
+          break;
+        }
+        case 'function-rpn': {
+          const fn = FUNCTIONS[token.name];
+          if (stack.length < fn.arity) {
+            throw new Error(`Function ${token.name} in ${scope} is missing operands`);
+          }
+          const args = stack.splice(stack.length - fn.arity, fn.arity);
+          const result = fn.apply(...args);
+          push(result);
+          break;
+        }
+        default:
+          throw new Error(`Unexpected token ${token.type} in formula for ${scope}`);
+      }
+    }
+
+    if (stack.length !== 1) {
+      throw new Error(`Formula in ${scope} did not resolve to a single value`);
+    }
+
+    return stack[0];
+  };
+}
+
+function tokenize(expr: string, scope: string): Token[] {
+  const tokens: Token[] = [];
+  let index = 0;
+  let expectValue = true;
+
+  const pushToken = (token: Token) => {
+    tokens.push(token);
+    if (
+      token.type === 'number' ||
+      token.type === 'identifier' ||
+      token.type === 'function-rpn'
+    ) {
+      expectValue = false;
+    } else if (token.type === 'paren' && token.value === '(') {
+      expectValue = true;
+    } else if (token.type === 'paren' && token.value === ')') {
+      expectValue = false;
+    } else if (token.type === 'comma') {
+      expectValue = true;
+    } else if (token.type === 'function') {
+      expectValue = true;
+    } else if (token.type === 'operator') {
+      expectValue = true;
+    }
+  };
+
+  while (index < expr.length) {
+    const ch = expr[index];
+    if (/\s/.test(ch)) {
+      index += 1;
+      continue;
+    }
+
+    if (/[0-9.]/.test(ch)) {
+      let end = index + 1;
+      while (end < expr.length && /[0-9.]/.test(expr[end])) end += 1;
+      const raw = expr.slice(index, end);
+      if (!/^\d*(\.\d+)?$/.test(raw)) {
+        throw new Error(`Invalid number '${raw}' in formula for ${scope}`);
+      }
+      pushToken({ type: 'number', value: Number(raw) });
+      index = end;
+      continue;
+    }
+
+    if (/[A-Za-z_]/.test(ch)) {
+      let end = index + 1;
+      while (end < expr.length && /[A-Za-z0-9_\.]/.test(expr[end])) end += 1;
+      const name = expr.slice(index, end);
+      let next = end;
+      while (next < expr.length && /\s/.test(expr[next])) next += 1;
+      if (next < expr.length && expr[next] === '(' && FUNCTIONS[name]) {
+        pushToken({ type: 'function', name: name as keyof typeof FUNCTIONS });
+      } else {
+        pushToken({ type: 'identifier', value: name });
+      }
+      index = end;
+      continue;
+    }
+
+    if (ch === '(' || ch === ')') {
+      pushToken({ type: 'paren', value: ch });
+      index += 1;
+      continue;
+    }
+
+    if (ch === ',') {
+      pushToken({ type: 'comma' });
+      index += 1;
+      continue;
+    }
+
+    if (ch === '+' || ch === '-' || ch === '*' || ch === '/' || ch === '%' || ch === '^') {
+      let op = ch;
+      if (expectValue) {
+        if (ch === '-') {
+          op = 'neg';
+        } else if (ch === '+') {
+          index += 1;
+          continue;
+        }
+      }
+      if (!OPERATORS[op]) {
+        throw new Error(`Operator '${ch}' is not supported in formula for ${scope}`);
+      }
+      pushToken({ type: 'operator', value: op as keyof typeof OPERATORS });
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unexpected character '${ch}' in formula for ${scope}`);
+  }
+
+  return tokens;
+}
+
+function toRpn(tokens: Token[], scope: string): Token[] {
+  const output: Token[] = [];
+  const stack: Token[] = [];
+
+  for (const token of tokens) {
+    switch (token.type) {
+      case 'number':
+      case 'identifier':
+        output.push(token);
+        break;
+      case 'function':
+        stack.push(token);
+        break;
+      case 'comma': {
+        while (stack.length && !(stack[stack.length - 1].type === 'paren' && (stack[stack.length - 1] as ParenToken).value === '(')) {
+          output.push(stack.pop()!);
+        }
+        if (!stack.length) {
+          throw new Error(`Misplaced comma in formula for ${scope}`);
+        }
+        break;
+      }
+      case 'operator': {
+        const op = OPERATORS[token.value];
+        while (stack.length) {
+          const top = stack[stack.length - 1];
+          if (top.type === 'operator') {
+            const topOp = OPERATORS[(top as OperatorToken).value];
+            const higher =
+              topOp.precedence > op.precedence ||
+              (topOp.precedence === op.precedence && op.assoc === 'left');
+            if (higher) {
+              output.push(stack.pop()!);
+              continue;
+            }
+          }
+          break;
+        }
+        stack.push(token);
+        break;
+      }
+      case 'paren':
+        if (token.value === '(') {
+          stack.push(token);
+        } else {
+          while (stack.length && !(stack[stack.length - 1].type === 'paren' && (stack[stack.length - 1] as ParenToken).value === '(')) {
+            output.push(stack.pop()!);
+          }
+          if (!stack.length) {
+            throw new Error(`Mismatched parentheses in formula for ${scope}`);
+          }
+          stack.pop();
+          if (stack.length && stack[stack.length - 1].type === 'function') {
+            const fn = stack.pop() as FunctionToken;
+            output.push({ type: 'function-rpn', name: fn.name });
+          }
+        }
+        break;
+      default:
+        throw new Error(`Unhandled token ${token.type} in formula for ${scope}`);
+    }
+  }
+
+  while (stack.length) {
+    const token = stack.pop()!;
+    if (token.type === 'paren') {
+      throw new Error(`Mismatched parentheses in formula for ${scope}`);
+    }
+    if (token.type === 'function') {
+      output.push({ type: 'function-rpn', name: token.name });
+    } else {
+      output.push(token);
+    }
+  }
+
+  return output;
+}
+
+function resolveIdentifier(
+  path: string,
+  user: Actor,
+  target: Actor,
+  ctx: FormulaContext,
+  scope: string,
+): number {
+  const root: Record<string, unknown> = { u: user, t: target, ctx, PI: Math.PI, E: Math.E };
+  const parts = path.split('.').filter(Boolean);
+  if (parts.length === 0) {
+    throw new Error(`Empty identifier in formula for ${scope}`);
+  }
+  let value: unknown = root[parts[0]];
+  for (let i = 1; i < parts.length; i += 1) {
+    if (value == null || typeof value !== 'object') {
+      throw new Error(`Identifier '${path}' is undefined in formula for ${scope}`);
+    }
+    value = (value as Record<string, unknown>)[parts[i]];
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0;
+  }
+  throw new Error(`Identifier '${path}' is not numeric in formula for ${scope}`);
+}
+
+function compileStatus(def: StatusDef, id: string, scope: string): RuntimeStatusTemplate {
+  const hooks = def.hooks ?? {};
+  return {
+    ...def,
+    id: def.id ?? id,
+    stackRule: def.stackRule ?? 'renew',
+    maxStacks: def.maxStacks ?? 1,
+    durationTurns: def.durationTurns ?? null,
+    tags: def.tags ? [...def.tags] : [],
+    modifiers: def.modifiers ? deepClone(def.modifiers) : undefined,
+    hooks: {
+      onApply: compileEffects(hooks.onApply ?? [], `${scope}.hooks.onApply`),
+      onTurnStart: compileEffects(hooks.onTurnStart ?? [], `${scope}.hooks.onTurnStart`),
+      onTurnEnd: compileEffects(hooks.onTurnEnd ?? [], `${scope}.hooks.onTurnEnd`),
+      onDealDamage: compileEffects(hooks.onDealDamage ?? [], `${scope}.hooks.onDealDamage`),
+      onTakeDamage: compileEffects(hooks.onTakeDamage ?? [], `${scope}.hooks.onTakeDamage`),
+      onExpire: compileEffects(hooks.onExpire ?? [], `${scope}.hooks.onExpire`),
+    },
+  };
+}
+
+function compileEnemyFactory(id: string, def: GameConfig['enemies'][string]): EnemyFactory {
+  return (level: number) => {
+    const lvl = Math.max(1, Math.floor(level || 1));
+    const base = def.base;
+    const scale = def.scale;
+    const stats = {
+      maxHp: base.maxHp + scale.maxHp * lvl,
+      maxSta: base.maxSta + scale.maxSta * lvl,
+      maxMp: base.maxMp + scale.maxMp * lvl,
+      atk: base.atk + scale.atk * lvl,
+      def: base.def + scale.def * lvl,
+    };
+    return {
+      id,
+      name: def.name ?? id,
+      color: def.color,
+      clazz: undefined,
+      stats: {
+        maxHp: stats.maxHp,
+        hp: stats.maxHp,
+        maxSta: stats.maxSta,
+        sta: stats.maxSta,
+        maxMp: stats.maxMp,
+        mp: stats.maxMp,
+        atk: stats.atk,
+        def: stats.def,
+        lv: lvl,
+        xp: 0,
+        gold: 0,
+      },
+      statuses: [],
+      alive: true,
+      tags: def.tags ? [...def.tags] : [],
+      meta: {
+        skillIds: def.skills ? [...def.skills] : [],
+        itemDrops: def.items ? def.items.map((item) => ({ ...item })) : undefined,
+      },
+    };
+  };
+}
+
+export function toSkills(cfg: GameConfig): AnyRecord<RuntimeSkill> {
+  const out: AnyRecord<RuntimeSkill> = {};
+  for (const [id, def] of Object.entries(cfg.skills)) {
+    out[id] = compileAction({ id, def, scope: `skills.${id}` }) as RuntimeSkill;
+  }
+  return out;
+}
+
+export function toItems(cfg: GameConfig): AnyRecord<RuntimeItem> {
+  const out: AnyRecord<RuntimeItem> = {};
+  for (const [id, def] of Object.entries(cfg.items)) {
+    out[id] = compileAction({ id, def, scope: `items.${id}` }) as RuntimeItem;
+  }
+  return out;
+}
+
+export function toStatuses(cfg: GameConfig): AnyRecord<RuntimeStatusTemplate> {
+  const out: AnyRecord<RuntimeStatusTemplate> = {};
+  for (const [id, def] of Object.entries(cfg.statuses)) {
+    out[id] = compileStatus(def, id, `statuses.${id}`);
+  }
+  return out;
+}
+
+export function toEnemies(cfg: GameConfig): AnyRecord<EnemyFactory> {
+  const out: AnyRecord<EnemyFactory> = {};
+  for (const [id, def] of Object.entries(cfg.enemies)) {
+    out[id] = compileEnemyFactory(id, def);
+  }
+  return out;
+}

--- a/minmmo/src/content/registry.ts
+++ b/minmmo/src/content/registry.ts
@@ -1,22 +1,32 @@
+import type { GameConfig, NPCDef } from '@config/schema';
+import { toEnemies, toItems, toSkills, toStatuses } from '@content/adapters';
+import type { RuntimeItem, RuntimeSkill, RuntimeStatusTemplate } from '@content/adapters';
+import type { Actor } from '@engine/battle/types';
 
-import type { GameConfig } from '@config/schema'
+type EnemyFactory = (level: number) => Actor;
 
-let skills:  Record<string, any> = {}
-let items:   Record<string, any> = {}
-let statuses:Record<string, any> = {}
-let enemies: Record<string, any> = {}
-let npcs:    Record<string, any> = {}
+type SkillMap = Record<string, RuntimeSkill>;
+type ItemMap = Record<string, RuntimeItem>;
+type StatusMap = Record<string, RuntimeStatusTemplate>;
+type EnemyMap = Record<string, EnemyFactory>;
+type NPCMap = Record<string, NPCDef>;
+
+let skills: SkillMap = {};
+let items: ItemMap = {};
+let statuses: StatusMap = {};
+let enemies: EnemyMap = {};
+let npcs: NPCMap = {};
 
 export function rebuildFromConfig(cfg: GameConfig) {
-  skills = { ...cfg.skills }
-  items = { ...cfg.items }
-  statuses = { ...cfg.statuses }
-  enemies = { ...cfg.enemies }
-  npcs = { ...cfg.npcs }
+  skills = toSkills(cfg);
+  items = toItems(cfg);
+  statuses = toStatuses(cfg);
+  enemies = toEnemies(cfg);
+  npcs = { ...cfg.npcs };
 }
 
-export const Skills   = () => skills
-export const Items    = () => items
-export const Statuses = () => statuses
-export const Enemies  = () => enemies
-export const NPCs     = () => npcs
+export const Skills = () => skills;
+export const Items = () => items;
+export const Statuses = () => statuses;
+export const Enemies = () => enemies;
+export const NPCs = () => npcs;

--- a/minmmo/src/content/validate.ts
+++ b/minmmo/src/content/validate.ts
@@ -1,1 +1,451 @@
-// TODO: implement zod validation + migrations
+import { DEFAULTS } from '@config/defaults';
+import type {
+  ClassPreset,
+  ClassSkills,
+  EnemyDef,
+  GameConfig,
+  ItemDef,
+  NPCDef,
+  SkillDef,
+  StackRule,
+  StartItems,
+  StatusDef,
+  TargetSelector,
+} from '@config/schema';
+import { z } from 'zod';
+
+type NonEmptyArray<T extends string> = readonly [T, ...T[]];
+
+const compareKeys = ['hpPct', 'staPct', 'mpPct', 'atk', 'def', 'lv', 'hasStatus', 'tag', 'clazz'] as const;
+const conditionOps = ['lt', 'lte', 'eq', 'gte', 'gt', 'ne', 'in', 'notIn'] as const;
+const resources = ['hp', 'sta', 'mp'] as const;
+const effectKinds = [
+  'damage',
+  'heal',
+  'resource',
+  'applyStatus',
+  'cleanseStatus',
+  'dispel',
+  'modifyStat',
+  'shield',
+  'taunt',
+  'flee',
+  'revive',
+  'summon',
+  'giveItem',
+  'removeItem',
+] as const;
+const targetSides = ['self', 'ally', 'enemy', 'any'] as const;
+const targetModes = ['self', 'single', 'all', 'random', 'lowest', 'highest', 'condition'] as const;
+const valueTypes = ['flat', 'percent', 'formula'] as const;
+const statKeys = ['atk', 'def', 'maxHp', 'maxSta', 'maxMp'] as const;
+const stackRuleValues = ['ignore', 'renew', 'stackCount', 'stackMagnitude'] as const satisfies readonly StackRule[];
+const stackRuleTuple = stackRuleValues as unknown as NonEmptyArray<StackRule>;
+
+const enumOptional = <T extends readonly [string, ...string[]]>(values: T) =>
+  z.preprocess((val) => (values.includes(val as string) ? val : undefined), z.enum(values).optional());
+
+const coerceNumber = () =>
+  z.preprocess((val) => {
+    if (val === '' || val === null || val === undefined) return undefined;
+    const num = Number(val);
+    return Number.isFinite(num) ? num : undefined;
+  }, z.number().finite().optional());
+
+const coerceBoolean = () =>
+  z.preprocess((val) => {
+    if (val === '' || val === null || val === undefined) return undefined;
+    if (typeof val === 'boolean') return val;
+    if (val === 'true') return true;
+    if (val === 'false') return false;
+    return undefined;
+  }, z.boolean().optional());
+
+const stringValue = () =>
+  z.preprocess((val) => {
+    if (val === null || val === undefined) return undefined;
+    return String(val);
+  }, z.string());
+
+const optionalString = () => stringValue().optional();
+
+const FilterSchema: z.ZodType<any> = z.lazy(() =>
+  z
+    .object({
+      all: z.array(FilterSchema).optional(),
+      any: z.array(FilterSchema).optional(),
+      not: FilterSchema.optional(),
+      test: z
+        .object({
+          key: enumOptional(compareKeys),
+          op: enumOptional(conditionOps),
+          value: z.any().optional(),
+        })
+        .partial()
+        .optional(),
+    })
+    .partial()
+    .strip()
+).catch({});
+
+const TargetSelectorSchema: z.ZodType<TargetSelector> = z
+  .object({
+    side: enumOptional(targetSides),
+    mode: enumOptional(targetModes),
+    count: coerceNumber(),
+    ofWhat: enumOptional(compareKeys),
+    condition: FilterSchema.optional(),
+    includeDead: coerceBoolean(),
+  })
+  .partial()
+  .strip()
+  .catch({ side: 'enemy', mode: 'single' } as TargetSelector);
+
+const EffectSchema = z
+  .object({
+    kind: enumOptional(effectKinds),
+    valueType: enumOptional(valueTypes),
+    amount: coerceNumber(),
+    percent: coerceNumber(),
+    formula: z
+      .object({ expr: optionalString() })
+      .partial()
+      .strip()
+      .optional(),
+    min: coerceNumber(),
+    max: coerceNumber(),
+    element: optionalString(),
+    canMiss: coerceBoolean(),
+    canCrit: coerceBoolean(),
+    resource: enumOptional(resources),
+    stat: enumOptional(statKeys),
+    statusId: optionalString(),
+    statusTurns: coerceNumber(),
+    cleanseTags: z.array(optionalString()).catch([]).optional(),
+    shieldId: optionalString(),
+    selector: TargetSelectorSchema.optional(),
+    onlyIf: FilterSchema.optional(),
+  })
+  .partial()
+  .strip()
+  .catch({ kind: 'damage' });
+
+const CostSchema = z
+  .object({
+    sta: coerceNumber(),
+    mp: coerceNumber(),
+    item: z
+      .object({
+        id: optionalString(),
+        qty: coerceNumber(),
+      })
+      .partial()
+      .strip()
+      .optional(),
+    cooldown: coerceNumber(),
+    charges: coerceNumber(),
+  })
+  .partial()
+  .strip()
+  .optional();
+
+const ActionBaseSchema = z
+  .object({
+    id: optionalString(),
+    name: optionalString(),
+    desc: optionalString(),
+    element: optionalString(),
+    targeting: TargetSelectorSchema.optional(),
+    effects: z.array(EffectSchema).catch([]).optional(),
+    canUse: FilterSchema.optional(),
+    costs: CostSchema,
+    aiWeight: coerceNumber(),
+  })
+  .partial()
+  .strip();
+
+const SkillSchema: z.ZodType<SkillDef> = ActionBaseSchema.extend({
+  type: z.literal('skill').optional(),
+}).strip() as z.ZodType<SkillDef>;
+
+const ItemSchema: z.ZodType<ItemDef> = ActionBaseSchema.extend({
+  type: z.literal('item').optional(),
+  consumable: coerceBoolean(),
+}).strip() as z.ZodType<ItemDef>;
+
+const StatusSchema: z.ZodType<StatusDef> = z
+  .object({
+    id: optionalString(),
+    name: optionalString(),
+    desc: optionalString(),
+    icon: optionalString(),
+    tags: z.array(optionalString()).catch([]).optional(),
+    maxStacks: coerceNumber(),
+    stackRule: enumOptional(stackRuleTuple),
+    durationTurns: coerceNumber(),
+    modifiers: z
+      .object({
+        atk: coerceNumber(),
+        def: coerceNumber(),
+        damageTakenPct: z.record(coerceNumber()).catch({}).optional(),
+        damageDealtPct: z.record(coerceNumber()).catch({}).optional(),
+        resourceRegenPerTurn: z.record(coerceNumber()).catch({}).optional(),
+        dodgeBonus: coerceNumber(),
+        critChanceBonus: coerceNumber(),
+        shield: z
+          .object({
+            id: optionalString(),
+            hp: coerceNumber(),
+            element: optionalString(),
+          })
+          .partial()
+          .strip()
+          .nullable()
+          .optional(),
+      })
+      .partial()
+      .strip()
+      .optional(),
+    hooks: z
+      .object({
+        onTurnStart: z.array(EffectSchema).catch([]).optional(),
+        onTurnEnd: z.array(EffectSchema).catch([]).optional(),
+        onDealDamage: z.array(EffectSchema).catch([]).optional(),
+        onTakeDamage: z.array(EffectSchema).catch([]).optional(),
+        onApply: z.array(EffectSchema).catch([]).optional(),
+        onExpire: z.array(EffectSchema).catch([]).optional(),
+      })
+      .partial()
+      .strip()
+      .optional(),
+  })
+  .partial()
+  .strip() as z.ZodType<StatusDef>;
+
+const StatsSchema = z
+  .object({
+    maxHp: coerceNumber(),
+    maxSta: coerceNumber(),
+    maxMp: coerceNumber(),
+    atk: coerceNumber(),
+    def: coerceNumber(),
+  })
+  .partial()
+  .strip();
+
+const ClassPresetSchema: z.ZodType<ClassPreset> = StatsSchema as z.ZodType<ClassPreset>;
+
+const ClassesSchema: z.ZodType<Record<string, ClassPreset>> = z.record(ClassPresetSchema).catch({});
+
+const ClassSkillsSchema: z.ZodType<ClassSkills> = z
+  .record(z.array(optionalString()).catch([]))
+  .catch({}) as z.ZodType<ClassSkills>;
+
+const StartItemsSchema: z.ZodType<StartItems> = z
+  .record(
+    z
+      .array(
+        z
+          .object({
+            id: optionalString(),
+            qty: coerceNumber(),
+          })
+          .partial()
+          .strip()
+      )
+      .catch([])
+  )
+  .catch({}) as z.ZodType<StartItems>;
+
+const EnemySchema: z.ZodType<EnemyDef> = z
+  .object({
+    name: optionalString(),
+    color: coerceNumber(),
+    base: StatsSchema,
+    scale: StatsSchema,
+    skills: z.array(optionalString()).catch([]).optional(),
+    items: z
+      .array(
+        z
+          .object({
+            id: optionalString(),
+            qty: coerceNumber(),
+          })
+          .partial()
+          .strip()
+      )
+      .catch([])
+      .optional(),
+    tags: z.array(optionalString()).catch([]).optional(),
+    ai: z
+      .object({
+        preferTags: z.array(optionalString()).catch([]).optional(),
+        avoidTags: z.array(optionalString()).catch([]).optional(),
+      })
+      .partial()
+      .strip()
+      .optional(),
+  })
+  .partial()
+  .strip() as z.ZodType<EnemyDef>;
+
+const NPCSchema: z.ZodType<NPCDef> = z
+  .object({
+    id: optionalString(),
+    name: optionalString(),
+    kind: optionalString(),
+    wander: z
+      .object({
+        speed: coerceNumber(),
+        region: optionalString(),
+      })
+      .partial()
+      .strip()
+      .optional(),
+    inventory: z
+      .array(
+        z
+          .object({
+            id: optionalString(),
+            qty: coerceNumber(),
+            price: coerceNumber(),
+            rarity: optionalString(),
+          })
+          .partial()
+          .strip()
+      )
+      .catch([])
+      .optional(),
+    trainer: z
+      .object({
+        clazz: optionalString(),
+        teaches: z.array(optionalString()).catch([]).optional(),
+        priceBySkill: z.record(coerceNumber()).catch({}).optional(),
+      })
+      .partial()
+      .strip()
+      .optional(),
+    dialogue: z
+      .object({
+        lines: z.array(optionalString()).catch([]).optional(),
+        options: z
+          .array(
+            z
+              .object({
+                text: optionalString(),
+                action: z.array(EffectSchema).catch([]).optional(),
+              })
+              .partial()
+              .strip()
+          )
+          .catch([])
+          .optional(),
+      })
+      .partial()
+      .strip()
+      .optional(),
+    respawnTurns: coerceNumber(),
+  })
+  .partial()
+  .strip() as z.ZodType<NPCDef>;
+
+const BalanceSchema = z
+  .object({
+    BASE_HIT: coerceNumber(),
+    BASE_CRIT: coerceNumber(),
+    CRIT_MULT: coerceNumber(),
+    DODGE_FLOOR: coerceNumber(),
+    HIT_CEIL: coerceNumber(),
+    ELEMENT_MATRIX: z.record(z.record(coerceNumber()).catch({})).catch({}),
+    RESISTS_BY_TAG: z.record(coerceNumber()).catch({}),
+    FLEE_BASE: coerceNumber(),
+    ECONOMY: z
+      .object({
+        buyMult: coerceNumber(),
+        sellMult: coerceNumber(),
+        restockTurns: coerceNumber(),
+        priceByRarity: z.record(coerceNumber()).catch({}),
+      })
+      .partial()
+      .strip(),
+    XP_CURVE: z
+      .object({
+        base: coerceNumber(),
+        growth: coerceNumber(),
+      })
+      .partial()
+      .strip(),
+    GOLD_DROP: z
+      .object({
+        mean: coerceNumber(),
+        variance: coerceNumber(),
+      })
+      .partial()
+      .strip(),
+    LOOT_ROLLS: coerceNumber(),
+    LEVEL_UNLOCK_INTERVAL: coerceNumber(),
+    SKILL_SLOTS_BY_LEVEL: z.array(coerceNumber()).catch([]),
+  })
+  .partial()
+  .strip();
+
+const GameConfigSchema: z.ZodType<Partial<GameConfig>> = z
+  .object({
+    __version: coerceNumber(),
+    classes: ClassesSchema.optional(),
+    classSkills: ClassSkillsSchema.optional(),
+    startItems: StartItemsSchema.optional(),
+    skills: z.record(SkillSchema).catch({}).optional(),
+    items: z.record(ItemSchema).catch({}).optional(),
+    statuses: z.record(StatusSchema).catch({}).optional(),
+    enemies: z.record(EnemySchema).catch({}).optional(),
+    balance: BalanceSchema.optional(),
+    elements: z.array(optionalString()).catch([]).optional(),
+    tags: z.array(optionalString()).catch([]).optional(),
+    npcs: z.record(NPCSchema).catch({}).optional(),
+  })
+  .partial()
+  .strip();
+
+function deepMerge<T>(base: T, patch: any): T {
+  if (Array.isArray(base)) {
+    if (Array.isArray(patch)) {
+      return (patch as any).slice();
+    }
+    return (base as any).slice();
+  }
+  if (typeof base === 'object' && base !== null) {
+    const result: any = { ...(base as any) };
+    if (typeof patch !== 'object' || patch === null) {
+      return result;
+    }
+    for (const key of Object.keys(patch)) {
+      const pVal = patch[key];
+      if (pVal === undefined || pVal === null) continue;
+      const bVal = (base as any)[key];
+      if (Array.isArray(pVal)) {
+        result[key] = pVal.slice();
+      } else if (typeof pVal === 'object') {
+        result[key] = deepMerge(bVal ?? {}, pVal);
+      } else {
+        result[key] = pVal;
+      }
+    }
+    return result;
+  }
+  return patch ?? base;
+}
+
+export function migrate(cfg: GameConfig): GameConfig {
+  if (!cfg.__version || cfg.__version === 1) {
+    return { ...cfg, __version: 1 };
+  }
+  return cfg;
+}
+
+export function validateAndRepair(input: unknown): GameConfig {
+  const parsed = GameConfigSchema.safeParse(input ?? {});
+  const partial = parsed.success ? parsed.data : {};
+  const merged = deepMerge(DEFAULTS, partial) as GameConfig;
+  return migrate(merged);
+}

--- a/minmmo/src/engine/battle/targeting.ts
+++ b/minmmo/src/engine/battle/targeting.ts
@@ -1,9 +1,302 @@
 
-import type { BattleState, Actor } from './types'
+import type {
+  CompareKey,
+  ConditionOp,
+  Filter,
+  TargetSelector,
+} from '@config/schema'
+
+import type { Actor, BattleState } from './types'
+
+const RNG_A = 1664525
+const RNG_C = 1013904223
+const RNG_M = 0x100000000
 
 export function getEnemies(state: BattleState): Actor[] {
-  return (state.sideEnemy ?? []).map(id => state.actors[id]).filter(Boolean) as Actor[]
+  return (state.sideEnemy ?? []).map((id) => state.actors[id]).filter(Boolean) as Actor[]
 }
+
 export function getAllies(state: BattleState): Actor[] {
-  return (state.sidePlayer ?? []).map(id => state.actors[id]).filter(Boolean) as Actor[]
+  return (state.sidePlayer ?? []).map((id) => state.actors[id]).filter(Boolean) as Actor[]
+}
+
+export function resolveTargets(
+  state: BattleState,
+  selector: TargetSelector,
+  userId: string,
+): string[] {
+  const user = state.actors[userId]
+  if (!user) {
+    return []
+  }
+
+  const includeDead = selector.includeDead ?? false
+  const baseCandidates = gatherCandidates(state, selector.side, userId, includeDead)
+
+  if (selector.mode === 'self') {
+    return includeDead || user.alive ? [userId] : []
+  }
+
+  let candidates = selector.condition
+    ? baseCandidates.filter((actor) => evaluateFilter(actor, selector.condition!))
+    : baseCandidates
+
+  if (!includeDead) {
+    candidates = candidates.filter((actor) => actor.alive)
+  }
+
+  if (candidates.length === 0) {
+    return []
+  }
+
+  switch (selector.mode) {
+    case 'single':
+      return [candidates[0].id]
+    case 'all':
+      return candidates.map((actor) => actor.id)
+    case 'random':
+      return pickRandom(state, candidates, normalizeCount('random', selector.count)).map(
+        (actor) => actor.id,
+      )
+    case 'lowest':
+    case 'highest': {
+      const sorted = sortByMetric(candidates, selector.ofWhat, selector.mode === 'lowest')
+      const limit = normalizeCount(selector.mode, selector.count)
+      return sorted.slice(0, limit || 1).map((actor) => actor.id)
+    }
+    case 'condition':
+      return candidates
+        .slice(0, selector.count != null ? Math.max(0, selector.count) : candidates.length)
+        .map((actor) => actor.id)
+    case 'self':
+    default:
+      return includeDead || user.alive ? [userId] : []
+  }
+}
+
+function gatherCandidates(
+  state: BattleState,
+  side: TargetSelector['side'],
+  userId: string,
+  includeDead: boolean,
+): Actor[] {
+  const user = state.actors[userId]
+  const sameSide = state.sidePlayer.includes(userId) ? state.sidePlayer : state.sideEnemy
+  const oppositeSide = sameSide === state.sidePlayer ? state.sideEnemy : state.sidePlayer
+
+  const fromIds = (ids: string[]): Actor[] =>
+    ids
+      .map((id) => state.actors[id])
+      .filter((actor): actor is Actor => Boolean(actor) && (includeDead || actor.alive))
+
+  switch (side) {
+    case 'self':
+      return includeDead || user?.alive ? [user].filter(Boolean) as Actor[] : []
+    case 'ally':
+      return fromIds(sameSide)
+    case 'enemy':
+      return fromIds(oppositeSide)
+    case 'any':
+      return [...fromIds(sameSide), ...fromIds(oppositeSide)]
+    default:
+      return []
+  }
+}
+
+function evaluateFilter(actor: Actor, filter: Filter): boolean {
+  let result = true
+
+  if (filter.test) {
+    result = result && evaluateTest(actor, filter.test)
+  }
+
+  if (filter.all) {
+    result = result && filter.all.every((inner) => evaluateFilter(actor, inner))
+  }
+
+  if (filter.any) {
+    result = result && filter.any.some((inner) => evaluateFilter(actor, inner))
+  }
+
+  if (filter.not) {
+    result = result && !evaluateFilter(actor, filter.not)
+  }
+
+  return result
+}
+
+function evaluateTest(
+  actor: Actor,
+  test: NonNullable<Filter['test']>,
+): boolean {
+  const { key, op, value } = test
+  switch (key) {
+    case 'hpPct':
+      return compareNumeric(fraction(actor.stats.hp, actor.stats.maxHp), op, value)
+    case 'staPct':
+      return compareNumeric(fraction(actor.stats.sta, actor.stats.maxSta), op, value)
+    case 'mpPct':
+      return compareNumeric(fraction(actor.stats.mp, actor.stats.maxMp), op, value)
+    case 'atk':
+      return compareNumeric(actor.stats.atk, op, value)
+    case 'def':
+      return compareNumeric(actor.stats.def, op, value)
+    case 'lv':
+      return compareNumeric(actor.stats.lv, op, value)
+    case 'hasStatus':
+      return compareSet(
+        actor.statuses.map((entry) => entry.id),
+        op,
+        value,
+      )
+    case 'tag':
+      return compareSet(actor.tags ?? [], op, value)
+    case 'clazz':
+      return compareValue(actor.clazz ?? null, op, value)
+    default:
+      return false
+  }
+}
+
+function compareNumeric(actual: number, op: ConditionOp, expected: unknown): boolean {
+  if (op === 'in' || op === 'notIn') {
+    const values = Array.isArray(expected) ? expected : [expected]
+    const numbers = values
+      .map((entry) => (typeof entry === 'number' ? entry : Number(entry)))
+      .filter((entry) => Number.isFinite(entry))
+    const has = numbers.some((entry) => entry === actual)
+    return op === 'in' ? has : !has
+  }
+
+  const expectedNumber = typeof expected === 'number' ? expected : Number(expected)
+  if (!Number.isFinite(expectedNumber)) {
+    return false
+  }
+
+  switch (op) {
+    case 'lt':
+      return actual < expectedNumber
+    case 'lte':
+      return actual <= expectedNumber
+    case 'eq':
+      return actual === expectedNumber
+    case 'gte':
+      return actual >= expectedNumber
+    case 'gt':
+      return actual > expectedNumber
+    case 'ne':
+      return actual !== expectedNumber
+    default:
+      return false
+  }
+}
+
+function compareValue(actual: unknown, op: ConditionOp, expected: unknown): boolean {
+  if (op === 'in' || op === 'notIn') {
+    const values = Array.isArray(expected) ? expected : [expected]
+    const has = values.some((entry) => entry === actual)
+    return op === 'in' ? has : !has
+  }
+
+  switch (op) {
+    case 'eq':
+      return actual === expected
+    case 'ne':
+      return actual !== expected
+    case 'lt':
+    case 'lte':
+    case 'gt':
+    case 'gte':
+      if (typeof actual === 'number' && typeof expected === 'number') {
+        return compareNumeric(actual, op, expected)
+      }
+      return false
+    default:
+      return false
+  }
+}
+
+function compareSet(actual: string[], op: ConditionOp, expected: unknown): boolean {
+  const values = Array.isArray(expected) ? expected : [expected]
+  const cleaned = values.filter((entry): entry is string => typeof entry === 'string')
+
+  switch (op) {
+    case 'eq':
+      return cleaned.every((entry) => actual.includes(entry))
+    case 'ne':
+      return cleaned.every((entry) => !actual.includes(entry))
+    case 'in':
+      return cleaned.some((entry) => actual.includes(entry))
+    case 'notIn':
+      return cleaned.every((entry) => !actual.includes(entry))
+    default:
+      return false
+  }
+}
+
+function normalizeCount(mode: TargetSelector['mode'], provided?: number): number {
+  if (provided != null) {
+    return Math.max(0, provided)
+  }
+  switch (mode) {
+    case 'single':
+      return 1
+    case 'random':
+      return 1
+    case 'lowest':
+    case 'highest':
+      return 1
+    default:
+      return 0
+  }
+}
+
+function fraction(current: number, max: number): number {
+  if (max <= 0) return 0
+  return current / max
+}
+
+function sortByMetric(actors: Actor[], key: CompareKey | undefined, asc: boolean): Actor[] {
+  const metricKey =
+    key && ['hpPct', 'staPct', 'mpPct', 'atk', 'def', 'lv'].includes(key) ? key : 'hpPct'
+  const scored = actors.map((actor) => ({ actor, value: getMetric(actor, metricKey as CompareKey) }))
+  scored.sort((a, b) => (asc ? a.value - b.value : b.value - a.value))
+  return scored.map((entry) => entry.actor)
+}
+
+function getMetric(actor: Actor, key: CompareKey): number {
+  switch (key) {
+    case 'hpPct':
+      return fraction(actor.stats.hp, actor.stats.maxHp)
+    case 'staPct':
+      return fraction(actor.stats.sta, actor.stats.maxSta)
+    case 'mpPct':
+      return fraction(actor.stats.mp, actor.stats.maxMp)
+    case 'atk':
+      return actor.stats.atk
+    case 'def':
+      return actor.stats.def
+    case 'lv':
+      return actor.stats.lv
+    default:
+      return fraction(actor.stats.hp, actor.stats.maxHp)
+  }
+}
+
+function pickRandom(state: BattleState, actors: Actor[], count: number): Actor[] {
+  if (count <= 0) return []
+  const pool = actors.slice()
+  const result: Actor[] = []
+  while (result.length < count && pool.length > 0) {
+    const index = Math.floor(nextRandom(state) * pool.length)
+    result.push(pool.splice(index, 1)[0])
+  }
+  return result
+}
+
+function nextRandom(state: BattleState): number {
+  const seed = state.rngSeed >>> 0
+  const next = (Math.imul(seed, RNG_A) + RNG_C) >>> 0
+  state.rngSeed = next
+  return next / RNG_M
 }

--- a/minmmo/tests/adapters.test.ts
+++ b/minmmo/tests/adapters.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULTS } from '@config/defaults';
+import { toEnemies, toItems, toSkills, toStatuses } from '@content/adapters';
+import type { GameConfig } from '@config/schema';
+import type { Actor } from '@engine/battle/types';
+
+function cloneDefaults(): GameConfig {
+  return JSON.parse(JSON.stringify(DEFAULTS)) as GameConfig;
+}
+
+describe('content adapters', () => {
+  const cfg: GameConfig = cloneDefaults();
+
+  cfg.skills = {
+    fireball: {
+      id: 'fireball',
+      type: 'skill',
+      name: 'Fireball',
+      targeting: { side: 'enemy', mode: 'single' },
+      effects: [
+        {
+          kind: 'damage',
+          valueType: 'formula',
+          formula: { expr: 'u.stats.atk * 4 - t.stats.def' },
+          min: 5,
+          max: 60,
+          canCrit: true,
+        },
+      ],
+      costs: { sta: 3 },
+    },
+  };
+
+  cfg.items = {
+    potion: {
+      id: 'potion',
+      type: 'item',
+      name: 'Potion',
+      targeting: { side: 'ally', mode: 'single' },
+      effects: [
+        {
+          kind: 'heal',
+          valueType: 'percent',
+          percent: 25,
+          min: 0,
+          max: 1,
+        },
+      ],
+      costs: { item: { id: 'potion', qty: 1 } },
+      consumable: true,
+    },
+  };
+
+  cfg.statuses = {
+    burn: {
+      id: 'burn',
+      name: 'Burn',
+      stackRule: 'stackCount',
+      maxStacks: 3,
+      durationTurns: 3,
+      tags: ['fire'],
+      modifiers: { shield: { id: 'burnShield', hp: 10 } },
+      hooks: {
+        onTurnEnd: [
+          { kind: 'damage', valueType: 'flat', amount: 5 },
+        ],
+      },
+    },
+  };
+
+  cfg.enemies = {
+    slime: {
+      name: 'Slime',
+      color: 0x00ff00,
+      base: { maxHp: 20, maxSta: 5, maxMp: 2, atk: 3, def: 1 },
+      scale: { maxHp: 4, maxSta: 1, maxMp: 0, atk: 1, def: 0 },
+      skills: ['fireball'],
+      items: [{ id: 'potion', qty: 1 }],
+      tags: ['slime'],
+    },
+  };
+
+  const makeActor = (overrides: Partial<Actor['stats']>): Actor => ({
+    id: 'hero',
+    name: 'Hero',
+    stats: {
+      maxHp: 100,
+      hp: 100,
+      maxSta: 50,
+      sta: 50,
+      maxMp: 30,
+      mp: 30,
+      atk: 10,
+      def: 5,
+      lv: 5,
+      xp: 0,
+      gold: 0,
+      ...overrides,
+    },
+    statuses: [],
+    alive: true,
+    tags: [],
+  });
+
+  it('compiles skills with formula values and clamps results', () => {
+    const skills = toSkills(cfg);
+    const fireball = skills.fireball;
+    expect(fireball).toBeDefined();
+    expect(fireball.effects[0].value.kind).toBe('formula');
+
+    const userHigh = makeActor({ atk: 20 });
+    const target = makeActor({ def: 0 });
+    const resolvedHigh = fireball.effects[0].value.resolve(userHigh, target, {});
+    expect(resolvedHigh).toBe(60);
+
+    const userLow = makeActor({ atk: 0 });
+    const resolvedLow = fireball.effects[0].value.resolve(userLow, target, {});
+    expect(resolvedLow).toBe(5);
+
+    expect(fireball.costs.sta).toBe(3);
+    expect(fireball.targeting.includeDead).toBe(false);
+  });
+
+  it('compiles items with percent values and normalized costs', () => {
+    const items = toItems(cfg);
+    const potion = items.potion;
+    expect(potion).toBeDefined();
+    expect(potion.effects[0].value.kind).toBe('percent');
+    expect(potion.effects[0].value.resolve(makeActor({}), makeActor({}), {})).toBeCloseTo(0.25);
+    expect(potion.costs.item).toEqual({ id: 'potion', qty: 1 });
+    expect(potion.consumable).toBe(true);
+  });
+
+  it('builds enemy factories that scale stats by level', () => {
+    const enemies = toEnemies(cfg);
+    const slimeFactory = enemies.slime;
+    const slime = slimeFactory(5);
+    expect(slime.stats.lv).toBe(5);
+    expect(slime.stats.maxHp).toBe(20 + 4 * 5);
+    expect(slime.stats.hp).toBe(slime.stats.maxHp);
+    expect(slime.tags).toEqual(['slime']);
+    expect(slime.meta?.skillIds).toEqual(['fireball']);
+  });
+
+  it('converts statuses into runtime templates with hooks', () => {
+    const statuses = toStatuses(cfg);
+    const burn = statuses.burn;
+    expect(burn.stackRule).toBe('stackCount');
+    expect(burn.maxStacks).toBe(3);
+    expect(burn.durationTurns).toBe(3);
+    expect(burn.tags).toEqual(['fire']);
+    expect(burn.modifiers?.shield?.id).toBe('burnShield');
+    expect(burn.hooks.onTurnEnd).toHaveLength(1);
+
+    const user = makeActor({});
+    const target = makeActor({});
+    expect(burn.hooks.onTurnEnd[0].value.resolve(user, target, {})).toBe(5);
+    expect(burn.hooks.onApply).toHaveLength(0);
+  });
+});

--- a/minmmo/tests/targeting.basic.test.ts
+++ b/minmmo/tests/targeting.basic.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveTargets } from '@engine/battle/targeting'
+import type { Actor, BattleState } from '@engine/battle/types'
+import type { TargetSelector } from '@config/schema'
+
+describe('resolveTargets', () => {
+  it('selects the first enemy for single targeting', () => {
+    const state = createState()
+    const selector: TargetSelector = { side: 'enemy', mode: 'single' }
+    expect(resolveTargets(state, selector, 'hero')).toEqual(['slime'])
+  })
+
+  it('returns all allies for all mode', () => {
+    const state = createState()
+    const selector: TargetSelector = { side: 'ally', mode: 'all' }
+    expect(resolveTargets(state, selector, 'hero')).toEqual(['hero', 'mage'])
+  })
+
+  it('respects includeDead flag', () => {
+    const state = createState()
+    state.actors.mage.alive = false
+    state.actors.mage.stats.hp = 0
+
+    const withoutDead: TargetSelector = { side: 'ally', mode: 'all' }
+    expect(resolveTargets(state, withoutDead, 'hero')).toEqual(['hero'])
+
+    const withDead: TargetSelector = { side: 'ally', mode: 'all', includeDead: true }
+    expect(resolveTargets(state, withDead, 'hero')).toEqual(['hero', 'mage'])
+  })
+
+  it('returns the user for self targeting', () => {
+    const state = createState()
+    const selector: TargetSelector = { side: 'self', mode: 'self' }
+    expect(resolveTargets(state, selector, 'hero')).toEqual(['hero'])
+  })
+
+  it('combines sides when targeting any', () => {
+    const state = createState()
+    const selector: TargetSelector = { side: 'any', mode: 'all' }
+    expect(resolveTargets(state, selector, 'hero')).toEqual([
+      'hero',
+      'mage',
+      'slime',
+      'goblin',
+    ])
+  })
+
+  it('picks unique random targets and advances rngSeed', () => {
+    const state = createState()
+    const ogre = makeActor('ogre', { tags: ['enemy'] })
+    state.actors.ogre = ogre
+    state.sideEnemy.push('ogre')
+    state.order.push('ogre')
+    state.rngSeed = 7
+
+    const selector: TargetSelector = { side: 'enemy', mode: 'random', count: 2 }
+    const result = resolveTargets(state, selector, 'hero')
+
+    expect(result.length).toBe(2)
+    expect(new Set(result).size).toBe(2)
+    expect(state.rngSeed).not.toBe(7)
+    expect(result.every((id) => ['slime', 'goblin', 'ogre'].includes(id))).toBe(true)
+  })
+
+  it('filters candidates using condition mode', () => {
+    const state = createState()
+    state.actors.slime.tags.push('boss')
+
+    const selector: TargetSelector = {
+      side: 'enemy',
+      mode: 'condition',
+      condition: { test: { key: 'tag', op: 'eq', value: 'boss' } },
+    }
+
+    expect(resolveTargets(state, selector, 'hero')).toEqual(['slime'])
+  })
+
+  it('orders by metric when using lowest mode', () => {
+    const state = createState()
+    state.actors.slime.stats.hp = 10
+    state.actors.slime.stats.maxHp = 100
+    state.actors.goblin.stats.hp = 40
+    state.actors.goblin.stats.maxHp = 80
+
+    const selector: TargetSelector = { side: 'enemy', mode: 'lowest', ofWhat: 'hpPct', count: 2 }
+    expect(resolveTargets(state, selector, 'hero')).toEqual(['slime', 'goblin'])
+  })
+})
+
+function createState(): BattleState {
+  const hero = makeActor('hero', { tags: ['player'] })
+  const mage = makeActor('mage', { tags: ['player'] })
+  const slime = makeActor('slime', { tags: ['enemy'] })
+  const goblin = makeActor('goblin', { tags: ['enemy'] })
+
+  return {
+    turn: 1,
+    order: [hero.id, mage.id, slime.id, goblin.id],
+    current: 0,
+    rngSeed: 1,
+    actors: {
+      [hero.id]: hero,
+      [mage.id]: mage,
+      [slime.id]: slime,
+      [goblin.id]: goblin,
+    },
+    sidePlayer: [hero.id, mage.id],
+    sideEnemy: [slime.id, goblin.id],
+    inventory: [],
+    log: [],
+  }
+}
+
+function makeActor(id: string, overrides: Partial<Actor> = {}): Actor {
+  const baseStats = {
+    maxHp: 100,
+    hp: 100,
+    maxSta: 50,
+    sta: 50,
+    maxMp: 30,
+    mp: 30,
+    atk: 10,
+    def: 5,
+    lv: 1,
+    xp: 0,
+    gold: 0,
+  }
+
+  return {
+    id,
+    name: overrides.name ?? id,
+    color: overrides.color,
+    clazz: overrides.clazz,
+    stats: { ...baseStats, ...(overrides.stats ?? {}) },
+    statuses: overrides.statuses ? overrides.statuses.map((entry) => ({ ...entry })) : [],
+    alive: overrides.alive ?? true,
+    tags: overrides.tags ? [...overrides.tags] : [],
+    meta: overrides.meta,
+  }
+}

--- a/minmmo/tests/validate.test.ts
+++ b/minmmo/tests/validate.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { validateAndRepair } from '@content/validate';
+import { DEFAULTS } from '@config/defaults';
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+
+  get length() {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+}
+
+const brokenConfig = {
+  __version: 1,
+  classes: {
+    Knight: { maxHp: 60 },
+  },
+  classSkills: { Knight: null },
+  startItems: { Knight: null },
+  skills: {},
+  items: {},
+  statuses: {},
+  enemies: {},
+  npcs: {},
+};
+
+describe('validateAndRepair', () => {
+  beforeEach(() => {
+    (globalThis as any).localStorage = new MemoryStorage();
+  });
+
+  it('fills missing branches from defaults', () => {
+    const repaired = validateAndRepair(brokenConfig as any);
+    expect(repaired.classes.Knight.maxHp).toBe(60);
+    expect(repaired.classes.Knight.def).toBe(DEFAULTS.classes.Knight.def);
+    expect(repaired.classes.Rogue).toEqual(DEFAULTS.classes.Rogue);
+    expect(repaired.startItems.Knight).toEqual([]);
+    expect(repaired.classSkills.Knight).toEqual([]);
+  });
+
+  it('round-trips through import/export with repairs', async () => {
+    const storage = new MemoryStorage();
+    (globalThis as any).localStorage = storage;
+    vi.resetModules();
+    const store = await import('@config/store');
+    store.importConfig(JSON.stringify(brokenConfig));
+    const exported = JSON.parse(store.exportConfig());
+    expect(exported.classes.Knight.maxHp).toBe(60);
+    expect(exported.startItems.Knight).toEqual([]);
+    expect(exported.classSkills.Knight).toEqual([]);
+  });
+
+  it('repairs persisted config on load', async () => {
+    const storage = new MemoryStorage();
+    storage.setItem('minmmo:config', JSON.stringify({
+      __version: 1,
+      startItems: { Knight: null },
+    }));
+    (globalThis as any).localStorage = storage;
+    vi.resetModules();
+    const store = await import('@config/store');
+    const cfg = store.load();
+    expect(cfg.startItems.Knight).toEqual([]);
+    expect(cfg.classes).toEqual(DEFAULTS.classes);
+  });
+});

--- a/minmmo/vitest.config.ts
+++ b/minmmo/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+const r = (p: string) => resolve(fileURLToPath(new URL('.', import.meta.url)), p);
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@app': r('src/app'),
+      '@config': r('src/config'),
+      '@content': r('src/content'),
+      '@engine': r('src/engine'),
+      '@game': r('src/game'),
+      '@cms': r('src/cms'),
+    },
+  },
+  test: {
+    environment: 'node',
+    globals: true,
+    passWithNoTests: true,
+  },
+});


### PR DESCRIPTION
## Summary
- implement battle target resolution that respects side/mode rules, stacked filters, and seeded randomness
- cover targeting flows with vitest cases for single/all/random, includeDead, conditions, and metric sorting

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d09c3d491483248f6fa5f22764a852