### PR TITLE
Run 9: overworld ui and autosave

### DIFF
--- a/minmmo/package-lock.json
+++ b/minmmo/package-lock.json
@@ -19,7 +19,8 @@
         "@types/react-dom": "^18.2.7",
         "@vitejs/plugin-react": "^4.2.0",
         "typescript": "^5.4.5",
-        "vite": "^5.2.0"
+        "vite": "^5.2.0",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1105,6 +1106,23 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1171,6 +1189,131 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.6.tgz",
@@ -1215,6 +1358,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001743",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
@@ -1235,6 +1388,33 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1268,12 +1448,29 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.222",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.222.tgz",
       "integrity": "sha512-gA7psSwSwQRE60CEoLz6JBCQPIxNeuzB2nL8vE03GK/OHxlvykbLyeiumQy1iH5C2f3YbRAZpGCMT12a/9ih9w==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1324,11 +1521,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1399,6 +1634,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1407,6 +1649,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/ms": {
@@ -1442,6 +1694,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/phaser": {
       "version": "3.90.0",
       "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.90.0.tgz",
@@ -1457,6 +1726,19 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -1583,6 +1865,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1591,6 +1880,101 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -1703,6 +2087,119 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/minmmo/package.json
+++ b/minmmo/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "phaser": "^3.90.0",
@@ -20,6 +21,7 @@
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.2.0",
     "typescript": "^5.4.5",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/minmmo/src/config/store.ts
+++ b/minmmo/src/config/store.ts
@@ -1,58 +1,58 @@
+import type { GameConfig } from './schema';
+import { validateAndRepair } from '@content/validate';
 
-import { DEFAULTS } from './defaults'
-import type { GameConfig } from './schema'
+const KEY = 'minmmo:config';
+const storage: Storage | undefined = typeof localStorage === 'undefined' ? undefined : localStorage;
+let current: GameConfig = validateAndRepair({});
+const subs = new Set<(cfg: GameConfig) => void>();
 
-const KEY = 'minmmo:config'
-let current: GameConfig = DEFAULTS
-const subs = new Set<(cfg: GameConfig)=>void>()
-
-function deepMerge<T>(base: T, patch: Partial<T>): T {
-  if (Array.isArray(base)) return (patch as any) ?? base as any
-  if (typeof base === 'object' && base) {
-    const out: any = { ...base }
-    for (const k of Object.keys(patch || {})) {
-      const pv: any = (patch as any)[k]
-      const bv: any = (base as any)[k]
-      out[k] = (bv && typeof bv === 'object' && !Array.isArray(bv)) ? deepMerge(bv, pv || {}) : (pv ?? bv)
-    }
-    return out
+function write(cfg: GameConfig) {
+  current = cfg;
+  if (storage) {
+    storage.setItem(KEY, JSON.stringify(cfg));
   }
-  return (patch as any) ?? base
+  for (const fn of subs) fn(current);
 }
 
 export function load(): GameConfig {
   try {
-    const raw = localStorage.getItem(KEY)
-    if (!raw) {
-      current = DEFAULTS
-    } else {
-      const parsed = JSON.parse(raw)
-      current = deepMerge(DEFAULTS, parsed)
+    if (!storage) {
+      current = validateAndRepair({});
+      return current;
     }
+    const raw = storage.getItem(KEY);
+    const parsed = raw ? JSON.parse(raw) : {};
+    const repaired = validateAndRepair(parsed);
+    current = repaired;
+    storage.setItem(KEY, JSON.stringify(repaired));
   } catch {
-    current = DEFAULTS
+    const repaired = validateAndRepair({});
+    current = repaired;
+    if (storage) {
+      storage.setItem(KEY, JSON.stringify(repaired));
+    }
   }
-  return current
+  return current;
 }
 
 export function save(cfg: GameConfig) {
-  current = deepMerge(DEFAULTS, cfg)
-  localStorage.setItem(KEY, JSON.stringify(current))
-  for (const fn of subs) fn(current)
+  const repaired = validateAndRepair(cfg);
+  write(repaired);
 }
 
 export function exportConfig(): string {
-  return JSON.stringify(current, null, 2)
+  return JSON.stringify(current, null, 2);
 }
 
 export function importConfig(json: string) {
-  const parsed = JSON.parse(json)
-  save(parsed)
+  const parsed = JSON.parse(json);
+  const repaired = validateAndRepair(parsed);
+  write(repaired);
 }
 
-export function subscribe(fn: (cfg: GameConfig)=>void) {
-  subs.add(fn)
-  return () => subs.delete(fn)
+export function subscribe(fn: (cfg: GameConfig) => void) {
+  subs.add(fn);
+  return () => subs.delete(fn);
 }
 
-export const CONFIG = () => current
+export const CONFIG = () => current;

--- a/minmmo/src/content/adapters.ts
+++ b/minmmo/src/content/adapters.ts
@@ -1,1 +1,671 @@
-// TODO: implement adapters to compile config defs into runtime actions/entities
+import type {
+  ActionBase,
+  Cost,
+  Effect,
+  Filter,
+  GameConfig,
+  ItemDef,
+  SkillDef,
+  StackRule,
+  StatusDef,
+  TargetSelector,
+  ValueType,
+} from '@config/schema';
+import type { Actor } from '@engine/battle/types';
+
+export type EnemyFactory = (level: number) => Actor;
+
+type AnyRecord<T> = Record<string, T>;
+
+type Assoc = 'left' | 'right';
+
+export type FormulaContext = Record<string, unknown>;
+
+export type ValueResolver = (user: Actor, target: Actor, ctx: FormulaContext) => number;
+
+interface OperatorConfig {
+  precedence: number;
+  assoc: Assoc;
+  args: number;
+  apply: (...args: number[]) => number;
+}
+
+interface FunctionConfig {
+  arity: number;
+  apply: (...args: number[]) => number;
+}
+
+interface TokenBase {
+  type: string;
+}
+
+interface NumberToken extends TokenBase {
+  type: 'number';
+  value: number;
+}
+
+interface IdentifierToken extends TokenBase {
+  type: 'identifier';
+  value: string;
+}
+
+interface OperatorToken extends TokenBase {
+  type: 'operator';
+  value: keyof typeof OPERATORS;
+}
+
+interface FunctionToken extends TokenBase {
+  type: 'function';
+  name: keyof typeof FUNCTIONS;
+}
+
+interface FunctionRpnToken extends TokenBase {
+  type: 'function-rpn';
+  name: keyof typeof FUNCTIONS;
+}
+
+interface ParenToken extends TokenBase {
+  type: 'paren';
+  value: '(' | ')';
+}
+
+interface CommaToken extends TokenBase {
+  type: 'comma';
+}
+
+type Token =
+  | NumberToken
+  | IdentifierToken
+  | OperatorToken
+  | FunctionToken
+  | FunctionRpnToken
+  | ParenToken
+  | CommaToken;
+
+export interface RuntimeCost {
+  sta: number;
+  mp: number;
+  item?: { id: string; qty: number };
+  cooldown: number;
+  charges?: number;
+}
+
+export interface RuntimeTargetSelector extends TargetSelector {
+  includeDead: boolean;
+  condition?: Filter;
+}
+
+export interface RuntimeValue {
+  kind: ValueType;
+  resolve: ValueResolver;
+  rawAmount?: number;
+  rawPercent?: number;
+  expr?: string;
+  min?: number;
+  max?: number;
+}
+
+export interface RuntimeEffect
+  extends Omit<Effect, 'valueType' | 'amount' | 'percent' | 'formula' | 'selector'> {
+  selector?: RuntimeTargetSelector;
+  value: RuntimeValue;
+}
+
+export interface RuntimeActionBase
+  extends Omit<ActionBase, 'targeting' | 'effects' | 'costs' | 'canUse'> {
+  targeting: RuntimeTargetSelector;
+  effects: RuntimeEffect[];
+  costs: RuntimeCost;
+  canUse?: Filter;
+}
+
+export interface RuntimeSkill extends RuntimeActionBase {
+  type: 'skill';
+}
+
+export interface RuntimeItem extends RuntimeActionBase {
+  type: 'item';
+  consumable: boolean;
+}
+
+export interface RuntimeStatusTemplate extends Omit<StatusDef, 'hooks'> {
+  stackRule: StackRule;
+  maxStacks: number;
+  durationTurns: number | null;
+  tags: string[];
+  modifiers: StatusDef['modifiers'];
+  hooks: {
+    onApply: RuntimeEffect[];
+    onTurnStart: RuntimeEffect[];
+    onTurnEnd: RuntimeEffect[];
+    onDealDamage: RuntimeEffect[];
+    onTakeDamage: RuntimeEffect[];
+    onExpire: RuntimeEffect[];
+  };
+}
+
+interface RuntimeActionContext<T extends SkillDef | ItemDef> {
+  id: string;
+  def: T;
+  scope: string;
+}
+
+const OPERATORS: Record<string, OperatorConfig> = {
+  '+': { precedence: 1, assoc: 'left', args: 2, apply: (a, b) => a + b },
+  '-': { precedence: 1, assoc: 'left', args: 2, apply: (a, b) => a - b },
+  '*': { precedence: 2, assoc: 'left', args: 2, apply: (a, b) => a * b },
+  '/': { precedence: 2, assoc: 'left', args: 2, apply: (a, b) => a / b },
+  '%': { precedence: 2, assoc: 'left', args: 2, apply: (a, b) => a % b },
+  '^': { precedence: 3, assoc: 'right', args: 2, apply: (a, b) => Math.pow(a, b) },
+  neg: { precedence: 4, assoc: 'right', args: 1, apply: (a) => -a },
+};
+
+const FUNCTIONS: Record<string, FunctionConfig> = {
+  min: { arity: 2, apply: (a, b) => Math.min(a, b) },
+  max: { arity: 2, apply: (a, b) => Math.max(a, b) },
+  floor: { arity: 1, apply: (a) => Math.floor(a) },
+  ceil: { arity: 1, apply: (a) => Math.ceil(a) },
+  abs: { arity: 1, apply: (a) => Math.abs(a) },
+  pow: { arity: 2, apply: (a, b) => Math.pow(a, b) },
+  clamp: { arity: 3, apply: (v, min, max) => Math.min(Math.max(v, min), max) },
+  round: { arity: 1, apply: (a) => Math.round(a) },
+  sqrt: { arity: 1, apply: (a) => Math.sqrt(a) },
+};
+
+function deepClone<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((entry) => deepClone(entry)) as unknown as T;
+  }
+  if (value && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      result[key] = deepClone(entry);
+    }
+    return result as T;
+  }
+  return value;
+}
+
+function normalizeSelector(selector?: TargetSelector): RuntimeTargetSelector {
+  const base: TargetSelector = selector
+    ? deepClone(selector)
+    : { side: 'enemy', mode: 'single', count: 1 };
+  return {
+    ...base,
+    count:
+      base.count ?? (base.mode === 'random' ? 1 : base.mode === 'single' ? 1 : base.count),
+    includeDead: Boolean(base.includeDead),
+    condition: base.condition ? deepClone(base.condition) : undefined,
+  };
+}
+
+function normalizeCost(costs?: Cost): RuntimeCost {
+  const src = costs ?? {};
+  return {
+    sta: src.sta ?? 0,
+    mp: src.mp ?? 0,
+    item: src.item ? { id: src.item.id, qty: src.item.qty ?? 1 } : undefined,
+    cooldown: src.cooldown ?? 0,
+    charges: src.charges ?? undefined,
+  };
+}
+
+function compileAction<T extends SkillDef | ItemDef>(context: RuntimeActionContext<T>): T extends SkillDef
+  ? RuntimeSkill
+  : RuntimeItem {
+  const { id, def, scope } = context;
+  const targeting = normalizeSelector(def.targeting);
+  const effects = compileEffects(def.effects ?? [], `${scope}.effects`);
+  const costs = normalizeCost(def.costs);
+  const canUse = def.canUse ? deepClone(def.canUse) : undefined;
+
+  const base: RuntimeActionBase = {
+    id,
+    name: def.name ?? id,
+    desc: def.desc,
+    element: def.element,
+    targeting,
+    effects,
+    costs,
+    canUse,
+    aiWeight: def.aiWeight ?? 1,
+  };
+
+  if (def.type === 'item') {
+    const item: RuntimeItem = {
+      ...base,
+      type: 'item',
+      consumable: def.consumable ?? true,
+    };
+    return item as unknown as T extends SkillDef ? RuntimeSkill : RuntimeItem;
+  }
+
+  const skill: RuntimeSkill = {
+    ...base,
+    type: 'skill',
+  };
+  return skill as unknown as T extends SkillDef ? RuntimeSkill : RuntimeItem;
+}
+
+function compileEffects(effects: Effect[], scope: string): RuntimeEffect[] {
+  return effects.map((effect, index) => compileEffect(effect, `${scope}[${index}]`));
+}
+
+function compileEffect(effect: Effect, scope: string): RuntimeEffect {
+  const selector = effect.selector ? normalizeSelector(effect.selector) : undefined;
+  const value = compileValue(effect, scope);
+  return {
+    kind: effect.kind,
+    element: effect.element,
+    canMiss: effect.canMiss ?? false,
+    canCrit: effect.canCrit ?? false,
+    resource: effect.resource,
+    stat: effect.stat,
+    statusId: effect.statusId,
+    statusTurns: effect.statusTurns,
+    cleanseTags: effect.cleanseTags ? [...effect.cleanseTags] : undefined,
+    shieldId: effect.shieldId,
+    onlyIf: effect.onlyIf ? deepClone(effect.onlyIf) : undefined,
+    selector,
+    value,
+  };
+}
+
+function compileValue(effect: Effect, scope: string): RuntimeValue {
+  const kind: ValueType = effect.valueType ?? (effect.percent != null ? 'percent' : 'flat');
+  const min = effect.min ?? undefined;
+  const max = effect.max ?? undefined;
+
+  const applyClamp = (resolver: ValueResolver): ValueResolver => {
+    return (user, target, ctx) => {
+      const raw = resolver(user, target, ctx);
+      const lower = min ?? -Infinity;
+      const upper = max ?? Infinity;
+      const clamped = Math.min(Math.max(raw, lower), upper);
+      return Number.isFinite(clamped) ? clamped : 0;
+    };
+  };
+
+  if (kind === 'formula') {
+    const expr = effect.formula?.expr ?? '0';
+    const resolver = compileFormula(expr, scope);
+    return {
+      kind,
+      resolve: applyClamp(resolver),
+      expr,
+      min,
+      max,
+    };
+  }
+
+  if (kind === 'percent') {
+    const percent = effect.percent ?? 0;
+    const resolver: ValueResolver = () => percent / 100;
+    return {
+      kind,
+      resolve: applyClamp(resolver),
+      rawPercent: percent,
+      min,
+      max,
+    };
+  }
+
+  const amount = effect.amount ?? 0;
+  const resolver: ValueResolver = () => amount;
+  return {
+    kind: 'flat',
+    resolve: applyClamp(resolver),
+    rawAmount: amount,
+    min,
+    max,
+  };
+}
+
+function compileFormula(expr: string, scope: string): ValueResolver {
+  const tokens = tokenize(expr, scope);
+  const rpn = toRpn(tokens, scope);
+  return (user, target, ctx) => {
+    const stack: number[] = [];
+    const push = (value: number) => {
+      if (!Number.isFinite(value)) {
+        throw new Error(`Formula in ${scope} evaluated to a non-finite number`);
+      }
+      stack.push(value);
+    };
+
+    for (const token of rpn) {
+      switch (token.type) {
+        case 'number':
+          push(token.value);
+          break;
+        case 'identifier':
+          push(resolveIdentifier(token.value, user, target, ctx, scope));
+          break;
+        case 'operator': {
+          const op = OPERATORS[token.value];
+          if (stack.length < op.args) {
+            throw new Error(`Operator ${token.value} in ${scope} is missing operands`);
+          }
+          const args = stack.splice(stack.length - op.args, op.args);
+          const result = op.apply(...args);
+          push(result);
+          break;
+        }
+        case 'function-rpn': {
+          const fn = FUNCTIONS[token.name];
+          if (stack.length < fn.arity) {
+            throw new Error(`Function ${token.name} in ${scope} is missing operands`);
+          }
+          const args = stack.splice(stack.length - fn.arity, fn.arity);
+          const result = fn.apply(...args);
+          push(result);
+          break;
+        }
+        default:
+          throw new Error(`Unexpected token ${token.type} in formula for ${scope}`);
+      }
+    }
+
+    if (stack.length !== 1) {
+      throw new Error(`Formula in ${scope} did not resolve to a single value`);
+    }
+
+    return stack[0];
+  };
+}
+
+function tokenize(expr: string, scope: string): Token[] {
+  const tokens: Token[] = [];
+  let index = 0;
+  let expectValue = true;
+
+  const pushToken = (token: Token) => {
+    tokens.push(token);
+    if (
+      token.type === 'number' ||
+      token.type === 'identifier' ||
+      token.type === 'function-rpn'
+    ) {
+      expectValue = false;
+    } else if (token.type === 'paren' && token.value === '(') {
+      expectValue = true;
+    } else if (token.type === 'paren' && token.value === ')') {
+      expectValue = false;
+    } else if (token.type === 'comma') {
+      expectValue = true;
+    } else if (token.type === 'function') {
+      expectValue = true;
+    } else if (token.type === 'operator') {
+      expectValue = true;
+    }
+  };
+
+  while (index < expr.length) {
+    const ch = expr[index];
+    if (/\s/.test(ch)) {
+      index += 1;
+      continue;
+    }
+
+    if (/[0-9.]/.test(ch)) {
+      let end = index + 1;
+      while (end < expr.length && /[0-9.]/.test(expr[end])) end += 1;
+      const raw = expr.slice(index, end);
+      if (!/^\d*(\.\d+)?$/.test(raw)) {
+        throw new Error(`Invalid number '${raw}' in formula for ${scope}`);
+      }
+      pushToken({ type: 'number', value: Number(raw) });
+      index = end;
+      continue;
+    }
+
+    if (/[A-Za-z_]/.test(ch)) {
+      let end = index + 1;
+      while (end < expr.length && /[A-Za-z0-9_\.]/.test(expr[end])) end += 1;
+      const name = expr.slice(index, end);
+      let next = end;
+      while (next < expr.length && /\s/.test(expr[next])) next += 1;
+      if (next < expr.length && expr[next] === '(' && FUNCTIONS[name]) {
+        pushToken({ type: 'function', name: name as keyof typeof FUNCTIONS });
+      } else {
+        pushToken({ type: 'identifier', value: name });
+      }
+      index = end;
+      continue;
+    }
+
+    if (ch === '(' || ch === ')') {
+      pushToken({ type: 'paren', value: ch });
+      index += 1;
+      continue;
+    }
+
+    if (ch === ',') {
+      pushToken({ type: 'comma' });
+      index += 1;
+      continue;
+    }
+
+    if (ch === '+' || ch === '-' || ch === '*' || ch === '/' || ch === '%' || ch === '^') {
+      let op = ch;
+      if (expectValue) {
+        if (ch === '-') {
+          op = 'neg';
+        } else if (ch === '+') {
+          index += 1;
+          continue;
+        }
+      }
+      if (!OPERATORS[op]) {
+        throw new Error(`Operator '${ch}' is not supported in formula for ${scope}`);
+      }
+      pushToken({ type: 'operator', value: op as keyof typeof OPERATORS });
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unexpected character '${ch}' in formula for ${scope}`);
+  }
+
+  return tokens;
+}
+
+function toRpn(tokens: Token[], scope: string): Token[] {
+  const output: Token[] = [];
+  const stack: Token[] = [];
+
+  for (const token of tokens) {
+    switch (token.type) {
+      case 'number':
+      case 'identifier':
+        output.push(token);
+        break;
+      case 'function':
+        stack.push(token);
+        break;
+      case 'comma': {
+        while (stack.length && !(stack[stack.length - 1].type === 'paren' && (stack[stack.length - 1] as ParenToken).value === '(')) {
+          output.push(stack.pop()!);
+        }
+        if (!stack.length) {
+          throw new Error(`Misplaced comma in formula for ${scope}`);
+        }
+        break;
+      }
+      case 'operator': {
+        const op = OPERATORS[token.value];
+        while (stack.length) {
+          const top = stack[stack.length - 1];
+          if (top.type === 'operator') {
+            const topOp = OPERATORS[(top as OperatorToken).value];
+            const higher =
+              topOp.precedence > op.precedence ||
+              (topOp.precedence === op.precedence && op.assoc === 'left');
+            if (higher) {
+              output.push(stack.pop()!);
+              continue;
+            }
+          }
+          break;
+        }
+        stack.push(token);
+        break;
+      }
+      case 'paren':
+        if (token.value === '(') {
+          stack.push(token);
+        } else {
+          while (stack.length && !(stack[stack.length - 1].type === 'paren' && (stack[stack.length - 1] as ParenToken).value === '(')) {
+            output.push(stack.pop()!);
+          }
+          if (!stack.length) {
+            throw new Error(`Mismatched parentheses in formula for ${scope}`);
+          }
+          stack.pop();
+          if (stack.length && stack[stack.length - 1].type === 'function') {
+            const fn = stack.pop() as FunctionToken;
+            output.push({ type: 'function-rpn', name: fn.name });
+          }
+        }
+        break;
+      default:
+        throw new Error(`Unhandled token ${token.type} in formula for ${scope}`);
+    }
+  }
+
+  while (stack.length) {
+    const token = stack.pop()!;
+    if (token.type === 'paren') {
+      throw new Error(`Mismatched parentheses in formula for ${scope}`);
+    }
+    if (token.type === 'function') {
+      output.push({ type: 'function-rpn', name: token.name });
+    } else {
+      output.push(token);
+    }
+  }
+
+  return output;
+}
+
+function resolveIdentifier(
+  path: string,
+  user: Actor,
+  target: Actor,
+  ctx: FormulaContext,
+  scope: string,
+): number {
+  const root: Record<string, unknown> = { u: user, t: target, ctx, PI: Math.PI, E: Math.E };
+  const parts = path.split('.').filter(Boolean);
+  if (parts.length === 0) {
+    throw new Error(`Empty identifier in formula for ${scope}`);
+  }
+  let value: unknown = root[parts[0]];
+  for (let i = 1; i < parts.length; i += 1) {
+    if (value == null || typeof value !== 'object') {
+      throw new Error(`Identifier '${path}' is undefined in formula for ${scope}`);
+    }
+    value = (value as Record<string, unknown>)[parts[i]];
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0;
+  }
+  throw new Error(`Identifier '${path}' is not numeric in formula for ${scope}`);
+}
+
+function compileStatus(def: StatusDef, id: string, scope: string): RuntimeStatusTemplate {
+  const hooks = def.hooks ?? {};
+  return {
+    ...def,
+    id: def.id ?? id,
+    stackRule: def.stackRule ?? 'renew',
+    maxStacks: def.maxStacks ?? 1,
+    durationTurns: def.durationTurns ?? null,
+    tags: def.tags ? [...def.tags] : [],
+    modifiers: def.modifiers ? deepClone(def.modifiers) : undefined,
+    hooks: {
+      onApply: compileEffects(hooks.onApply ?? [], `${scope}.hooks.onApply`),
+      onTurnStart: compileEffects(hooks.onTurnStart ?? [], `${scope}.hooks.onTurnStart`),
+      onTurnEnd: compileEffects(hooks.onTurnEnd ?? [], `${scope}.hooks.onTurnEnd`),
+      onDealDamage: compileEffects(hooks.onDealDamage ?? [], `${scope}.hooks.onDealDamage`),
+      onTakeDamage: compileEffects(hooks.onTakeDamage ?? [], `${scope}.hooks.onTakeDamage`),
+      onExpire: compileEffects(hooks.onExpire ?? [], `${scope}.hooks.onExpire`),
+    },
+  };
+}
+
+function compileEnemyFactory(id: string, def: GameConfig['enemies'][string]): EnemyFactory {
+  return (level: number) => {
+    const lvl = Math.max(1, Math.floor(level || 1));
+    const base = def.base;
+    const scale = def.scale;
+    const stats = {
+      maxHp: base.maxHp + scale.maxHp * lvl,
+      maxSta: base.maxSta + scale.maxSta * lvl,
+      maxMp: base.maxMp + scale.maxMp * lvl,
+      atk: base.atk + scale.atk * lvl,
+      def: base.def + scale.def * lvl,
+    };
+    return {
+      id,
+      name: def.name ?? id,
+      color: def.color,
+      clazz: undefined,
+      stats: {
+        maxHp: stats.maxHp,
+        hp: stats.maxHp,
+        maxSta: stats.maxSta,
+        sta: stats.maxSta,
+        maxMp: stats.maxMp,
+        mp: stats.maxMp,
+        atk: stats.atk,
+        def: stats.def,
+        lv: lvl,
+        xp: 0,
+        gold: 0,
+      },
+      statuses: [],
+      alive: true,
+      tags: def.tags ? [...def.tags] : [],
+      meta: {
+        skillIds: def.skills ? [...def.skills] : [],
+        itemDrops: def.items ? def.items.map((item) => ({ ...item })) : undefined,
+      },
+    };
+  };
+}
+
+export function toSkills(cfg: GameConfig): AnyRecord<RuntimeSkill> {
+  const out: AnyRecord<RuntimeSkill> = {};
+  for (const [id, def] of Object.entries(cfg.skills)) {
+    out[id] = compileAction({ id, def, scope: `skills.${id}` }) as RuntimeSkill;
+  }
+  return out;
+}
+
+export function toItems(cfg: GameConfig): AnyRecord<RuntimeItem> {
+  const out: AnyRecord<RuntimeItem> = {};
+  for (const [id, def] of Object.entries(cfg.items)) {
+    out[id] = compileAction({ id, def, scope: `items.${id}` }) as RuntimeItem;
+  }
+  return out;
+}
+
+export function toStatuses(cfg: GameConfig): AnyRecord<RuntimeStatusTemplate> {
+  const out: AnyRecord<RuntimeStatusTemplate> = {};
+  for (const [id, def] of Object.entries(cfg.statuses)) {
+    out[id] = compileStatus(def, id, `statuses.${id}`);
+  }
+  return out;
+}
+
+export function toEnemies(cfg: GameConfig): AnyRecord<EnemyFactory> {
+  const out: AnyRecord<EnemyFactory> = {};
+  for (const [id, def] of Object.entries(cfg.enemies)) {
+    out[id] = compileEnemyFactory(id, def);
+  }
+  return out;
+}

--- a/minmmo/src/content/registry.ts
+++ b/minmmo/src/content/registry.ts
@@ -1,22 +1,32 @@
+import type { GameConfig, NPCDef } from '@config/schema';
+import { toEnemies, toItems, toSkills, toStatuses } from '@content/adapters';
+import type { RuntimeItem, RuntimeSkill, RuntimeStatusTemplate } from '@content/adapters';
+import type { Actor } from '@engine/battle/types';
 
-import type { GameConfig } from '@config/schema'
+type EnemyFactory = (level: number) => Actor;
 
-let skills:  Record<string, any> = {}
-let items:   Record<string, any> = {}
-let statuses:Record<string, any> = {}
-let enemies: Record<string, any> = {}
-let npcs:    Record<string, any> = {}
+type SkillMap = Record<string, RuntimeSkill>;
+type ItemMap = Record<string, RuntimeItem>;
+type StatusMap = Record<string, RuntimeStatusTemplate>;
+type EnemyMap = Record<string, EnemyFactory>;
+type NPCMap = Record<string, NPCDef>;
+
+let skills: SkillMap = {};
+let items: ItemMap = {};
+let statuses: StatusMap = {};
+let enemies: EnemyMap = {};
+let npcs: NPCMap = {};
 
 export function rebuildFromConfig(cfg: GameConfig) {
-  skills = { ...cfg.skills }
-  items = { ...cfg.items }
-  statuses = { ...cfg.statuses }
-  enemies = { ...cfg.enemies }
-  npcs = { ...cfg.npcs }
+  skills = toSkills(cfg);
+  items = toItems(cfg);
+  statuses = toStatuses(cfg);
+  enemies = toEnemies(cfg);
+  npcs = { ...cfg.npcs };
 }
 
-export const Skills   = () => skills
-export const Items    = () => items
-export const Statuses = () => statuses
-export const Enemies  = () => enemies
-export const NPCs     = () => npcs
+export const Skills = () => skills;
+export const Items = () => items;
+export const Statuses = () => statuses;
+export const Enemies = () => enemies;
+export const NPCs = () => npcs;

--- a/minmmo/src/content/validate.ts
+++ b/minmmo/src/content/validate.ts
@@ -1,1 +1,451 @@
-// TODO: implement zod validation + migrations
+import { DEFAULTS } from '@config/defaults';
+import type {
+  ClassPreset,
+  ClassSkills,
+  EnemyDef,
+  GameConfig,
+  ItemDef,
+  NPCDef,
+  SkillDef,
+  StackRule,
+  StartItems,
+  StatusDef,
+  TargetSelector,
+} from '@config/schema';
+import { z } from 'zod';
+
+type NonEmptyArray<T extends string> = readonly [T, ...T[]];
+
+const compareKeys = ['hpPct', 'staPct', 'mpPct', 'atk', 'def', 'lv', 'hasStatus', 'tag', 'clazz'] as const;
+const conditionOps = ['lt', 'lte', 'eq', 'gte', 'gt', 'ne', 'in', 'notIn'] as const;
+const resources = ['hp', 'sta', 'mp'] as const;
+const effectKinds = [
+  'damage',
+  'heal',
+  'resource',
+  'applyStatus',
+  'cleanseStatus',
+  'dispel',
+  'modifyStat',
+  'shield',
+  'taunt',
+  'flee',
+  'revive',
+  'summon',
+  'giveItem',
+  'removeItem',
+] as const;
+const targetSides = ['self', 'ally', 'enemy', 'any'] as const;
+const targetModes = ['self', 'single', 'all', 'random', 'lowest', 'highest', 'condition'] as const;
+const valueTypes = ['flat', 'percent', 'formula'] as const;
+const statKeys = ['atk', 'def', 'maxHp', 'maxSta', 'maxMp'] as const;
+const stackRuleValues = ['ignore', 'renew', 'stackCount', 'stackMagnitude'] as const satisfies readonly StackRule[];
+const stackRuleTuple = stackRuleValues as unknown as NonEmptyArray<StackRule>;
+
+const enumOptional = <T extends readonly [string, ...string[]]>(values: T) =>
+  z.preprocess((val) => (values.includes(val as string) ? val : undefined), z.enum(values).optional());
+
+const coerceNumber = () =>
+  z.preprocess((val) => {
+    if (val === '' || val === null || val === undefined) return undefined;
+    const num = Number(val);
+    return Number.isFinite(num) ? num : undefined;
+  }, z.number().finite().optional());
+
+const coerceBoolean = () =>
+  z.preprocess((val) => {
+    if (val === '' || val === null || val === undefined) return undefined;
+    if (typeof val === 'boolean') return val;
+    if (val === 'true') return true;
+    if (val === 'false') return false;
+    return undefined;
+  }, z.boolean().optional());
+
+const stringValue = () =>
+  z.preprocess((val) => {
+    if (val === null || val === undefined) return undefined;
+    return String(val);
+  }, z.string());
+
+const optionalString = () => stringValue().optional();
+
+const FilterSchema: z.ZodType<any> = z.lazy(() =>
+  z
+    .object({
+      all: z.array(FilterSchema).optional(),
+      any: z.array(FilterSchema).optional(),
+      not: FilterSchema.optional(),
+      test: z
+        .object({
+          key: enumOptional(compareKeys),
+          op: enumOptional(conditionOps),
+          value: z.any().optional(),
+        })
+        .partial()
+        .optional(),
+    })
+    .partial()
+    .strip()
+).catch({});
+
+const TargetSelectorSchema: z.ZodType<TargetSelector> = z
+  .object({
+    side: enumOptional(targetSides),
+    mode: enumOptional(targetModes),
+    count: coerceNumber(),
+    ofWhat: enumOptional(compareKeys),
+    condition: FilterSchema.optional(),
+    includeDead: coerceBoolean(),
+  })
+  .partial()
+  .strip()
+  .catch({ side: 'enemy', mode: 'single' } as TargetSelector);
+
+const EffectSchema = z
+  .object({
+    kind: enumOptional(effectKinds),
+    valueType: enumOptional(valueTypes),
+    amount: coerceNumber(),
+    percent: coerceNumber(),
+    formula: z
+      .object({ expr: optionalString() })
+      .partial()
+      .strip()
+      .optional(),
+    min: coerceNumber(),
+    max: coerceNumber(),
+    element: optionalString(),
+    canMiss: coerceBoolean(),
+    canCrit: coerceBoolean(),
+    resource: enumOptional(resources),
+    stat: enumOptional(statKeys),
+    statusId: optionalString(),
+    statusTurns: coerceNumber(),
+    cleanseTags: z.array(optionalString()).catch([]).optional(),
+    shieldId: optionalString(),
+    selector: TargetSelectorSchema.optional(),
+    onlyIf: FilterSchema.optional(),
+  })
+  .partial()
+  .strip()
+  .catch({ kind: 'damage' });
+
+const CostSchema = z
+  .object({
+    sta: coerceNumber(),
+    mp: coerceNumber(),
+    item: z
+      .object({
+        id: optionalString(),
+        qty: coerceNumber(),
+      })
+      .partial()
+      .strip()
+      .optional(),
+    cooldown: coerceNumber(),
+    charges: coerceNumber(),
+  })
+  .partial()
+  .strip()
+  .optional();
+
+const ActionBaseSchema = z
+  .object({
+    id: optionalString(),
+    name: optionalString(),
+    desc: optionalString(),
+    element: optionalString(),
+    targeting: TargetSelectorSchema.optional(),
+    effects: z.array(EffectSchema).catch([]).optional(),
+    canUse: FilterSchema.optional(),
+    costs: CostSchema,
+    aiWeight: coerceNumber(),
+  })
+  .partial()
+  .strip();
+
+const SkillSchema: z.ZodType<SkillDef> = ActionBaseSchema.extend({
+  type: z.literal('skill').optional(),
+}).strip() as z.ZodType<SkillDef>;
+
+const ItemSchema: z.ZodType<ItemDef> = ActionBaseSchema.extend({
+  type: z.literal('item').optional(),
+  consumable: coerceBoolean(),
+}).strip() as z.ZodType<ItemDef>;
+
+const StatusSchema: z.ZodType<StatusDef> = z
+  .object({
+    id: optionalString(),
+    name: optionalString(),
+    desc: optionalString(),
+    icon: optionalString(),
+    tags: z.array(optionalString()).catch([]).optional(),
+    maxStacks: coerceNumber(),
+    stackRule: enumOptional(stackRuleTuple),
+    durationTurns: coerceNumber(),
+    modifiers: z
+      .object({
+        atk: coerceNumber(),
+        def: coerceNumber(),
+        damageTakenPct: z.record(coerceNumber()).catch({}).optional(),
+        damageDealtPct: z.record(coerceNumber()).catch({}).optional(),
+        resourceRegenPerTurn: z.record(coerceNumber()).catch({}).optional(),
+        dodgeBonus: coerceNumber(),
+        critChanceBonus: coerceNumber(),
+        shield: z
+          .object({
+            id: optionalString(),
+            hp: coerceNumber(),
+            element: optionalString(),
+          })
+          .partial()
+          .strip()
+          .nullable()
+          .optional(),
+      })
+      .partial()
+      .strip()
+      .optional(),
+    hooks: z
+      .object({
+        onTurnStart: z.array(EffectSchema).catch([]).optional(),
+        onTurnEnd: z.array(EffectSchema).catch([]).optional(),
+        onDealDamage: z.array(EffectSchema).catch([]).optional(),
+        onTakeDamage: z.array(EffectSchema).catch([]).optional(),
+        onApply: z.array(EffectSchema).catch([]).optional(),
+        onExpire: z.array(EffectSchema).catch([]).optional(),
+      })
+      .partial()
+      .strip()
+      .optional(),
+  })
+  .partial()
+  .strip() as z.ZodType<StatusDef>;
+
+const StatsSchema = z
+  .object({
+    maxHp: coerceNumber(),
+    maxSta: coerceNumber(),
+    maxMp: coerceNumber(),
+    atk: coerceNumber(),
+    def: coerceNumber(),
+  })
+  .partial()
+  .strip();
+
+const ClassPresetSchema: z.ZodType<ClassPreset> = StatsSchema as z.ZodType<ClassPreset>;
+
+const ClassesSchema: z.ZodType<Record<string, ClassPreset>> = z.record(ClassPresetSchema).catch({});
+
+const ClassSkillsSchema: z.ZodType<ClassSkills> = z
+  .record(z.array(optionalString()).catch([]))
+  .catch({}) as z.ZodType<ClassSkills>;
+
+const StartItemsSchema: z.ZodType<StartItems> = z
+  .record(
+    z
+      .array(
+        z
+          .object({
+            id: optionalString(),
+            qty: coerceNumber(),
+          })
+          .partial()
+          .strip()
+      )
+      .catch([])
+  )
+  .catch({}) as z.ZodType<StartItems>;
+
+const EnemySchema: z.ZodType<EnemyDef> = z
+  .object({
+    name: optionalString(),
+    color: coerceNumber(),
+    base: StatsSchema,
+    scale: StatsSchema,
+    skills: z.array(optionalString()).catch([]).optional(),
+    items: z
+      .array(
+        z
+          .object({
+            id: optionalString(),
+            qty: coerceNumber(),
+          })
+          .partial()
+          .strip()
+      )
+      .catch([])
+      .optional(),
+    tags: z.array(optionalString()).catch([]).optional(),
+    ai: z
+      .object({
+        preferTags: z.array(optionalString()).catch([]).optional(),
+        avoidTags: z.array(optionalString()).catch([]).optional(),
+      })
+      .partial()
+      .strip()
+      .optional(),
+  })
+  .partial()
+  .strip() as z.ZodType<EnemyDef>;
+
+const NPCSchema: z.ZodType<NPCDef> = z
+  .object({
+    id: optionalString(),
+    name: optionalString(),
+    kind: optionalString(),
+    wander: z
+      .object({
+        speed: coerceNumber(),
+        region: optionalString(),
+      })
+      .partial()
+      .strip()
+      .optional(),
+    inventory: z
+      .array(
+        z
+          .object({
+            id: optionalString(),
+            qty: coerceNumber(),
+            price: coerceNumber(),
+            rarity: optionalString(),
+          })
+          .partial()
+          .strip()
+      )
+      .catch([])
+      .optional(),
+    trainer: z
+      .object({
+        clazz: optionalString(),
+        teaches: z.array(optionalString()).catch([]).optional(),
+        priceBySkill: z.record(coerceNumber()).catch({}).optional(),
+      })
+      .partial()
+      .strip()
+      .optional(),
+    dialogue: z
+      .object({
+        lines: z.array(optionalString()).catch([]).optional(),
+        options: z
+          .array(
+            z
+              .object({
+                text: optionalString(),
+                action: z.array(EffectSchema).catch([]).optional(),
+              })
+              .partial()
+              .strip()
+          )
+          .catch([])
+          .optional(),
+      })
+      .partial()
+      .strip()
+      .optional(),
+    respawnTurns: coerceNumber(),
+  })
+  .partial()
+  .strip() as z.ZodType<NPCDef>;
+
+const BalanceSchema = z
+  .object({
+    BASE_HIT: coerceNumber(),
+    BASE_CRIT: coerceNumber(),
+    CRIT_MULT: coerceNumber(),
+    DODGE_FLOOR: coerceNumber(),
+    HIT_CEIL: coerceNumber(),
+    ELEMENT_MATRIX: z.record(z.record(coerceNumber()).catch({})).catch({}),
+    RESISTS_BY_TAG: z.record(coerceNumber()).catch({}),
+    FLEE_BASE: coerceNumber(),
+    ECONOMY: z
+      .object({
+        buyMult: coerceNumber(),
+        sellMult: coerceNumber(),
+        restockTurns: coerceNumber(),
+        priceByRarity: z.record(coerceNumber()).catch({}),
+      })
+      .partial()
+      .strip(),
+    XP_CURVE: z
+      .object({
+        base: coerceNumber(),
+        growth: coerceNumber(),
+      })
+      .partial()
+      .strip(),
+    GOLD_DROP: z
+      .object({
+        mean: coerceNumber(),
+        variance: coerceNumber(),
+      })
+      .partial()
+      .strip(),
+    LOOT_ROLLS: coerceNumber(),
+    LEVEL_UNLOCK_INTERVAL: coerceNumber(),
+    SKILL_SLOTS_BY_LEVEL: z.array(coerceNumber()).catch([]),
+  })
+  .partial()
+  .strip();
+
+const GameConfigSchema: z.ZodType<Partial<GameConfig>> = z
+  .object({
+    __version: coerceNumber(),
+    classes: ClassesSchema.optional(),
+    classSkills: ClassSkillsSchema.optional(),
+    startItems: StartItemsSchema.optional(),
+    skills: z.record(SkillSchema).catch({}).optional(),
+    items: z.record(ItemSchema).catch({}).optional(),
+    statuses: z.record(StatusSchema).catch({}).optional(),
+    enemies: z.record(EnemySchema).catch({}).optional(),
+    balance: BalanceSchema.optional(),
+    elements: z.array(optionalString()).catch([]).optional(),
+    tags: z.array(optionalString()).catch([]).optional(),
+    npcs: z.record(NPCSchema).catch({}).optional(),
+  })
+  .partial()
+  .strip();
+
+function deepMerge<T>(base: T, patch: any): T {
+  if (Array.isArray(base)) {
+    if (Array.isArray(patch)) {
+      return (patch as any).slice();
+    }
+    return (base as any).slice();
+  }
+  if (typeof base === 'object' && base !== null) {
+    const result: any = { ...(base as any) };
+    if (typeof patch !== 'object' || patch === null) {
+      return result;
+    }
+    for (const key of Object.keys(patch)) {
+      const pVal = patch[key];
+      if (pVal === undefined || pVal === null) continue;
+      const bVal = (base as any)[key];
+      if (Array.isArray(pVal)) {
+        result[key] = pVal.slice();
+      } else if (typeof pVal === 'object') {
+        result[key] = deepMerge(bVal ?? {}, pVal);
+      } else {
+        result[key] = pVal;
+      }
+    }
+    return result;
+  }
+  return patch ?? base;
+}
+
+export function migrate(cfg: GameConfig): GameConfig {
+  if (!cfg.__version || cfg.__version === 1) {
+    return { ...cfg, __version: 1 };
+  }
+  return cfg;
+}
+
+export function validateAndRepair(input: unknown): GameConfig {
+  const parsed = GameConfigSchema.safeParse(input ?? {});
+  const partial = parsed.success ? parsed.data : {};
+  const merged = deepMerge(DEFAULTS, partial) as GameConfig;
+  return migrate(merged);
+}

--- a/minmmo/src/engine/battle/actions.ts
+++ b/minmmo/src/engine/battle/actions.ts
@@ -1,18 +1,844 @@
 
-import type { BattleState } from './types'
+import type {
+  FormulaContext,
+  RuntimeEffect,
+  RuntimeItem,
+  RuntimeSkill,
+  RuntimeTargetSelector,
+  ValueResolver,
+} from '@content/adapters'
+import type { ConditionOp, Filter, Resource } from '@config/schema'
+import { CONFIG } from '@config/store'
 
-export function useSkill(state: BattleState, skill: any, userId: string, targetIds?: string[]) {
-  state.log.push(`[skill] ${skill?.name ?? 'Unknown'} used by ${userId}`)
-  return state
+import { resolveTargets } from './targeting'
+import { critChance, elementMult, hitChance, tagResistMult, type RuleContext } from './rules'
+import {
+  absorbDamageWithShields,
+  applyStatus,
+  applyTaunt,
+  cleanseStatuses,
+  grantShield,
+  tickEndOfTurn,
+  triggerStatusHooks,
+} from './status'
+import type { Actor, BattleState, ChargeState, UseResult } from './types'
+
+const RNG_A = 1664525
+const RNG_C = 1013904223
+const RNG_M = 0x100000000
+
+type RuntimeAction = RuntimeSkill | RuntimeItem
+
+export function useSkill(
+  state: BattleState,
+  skill: RuntimeSkill,
+  userId: string,
+  targetIds?: string[],
+): UseResult {
+  return executeAction(state, skill, userId, targetIds)
 }
 
-export function useItem(state: BattleState, item: any, userId: string, targetIds?: string[]) {
-  state.log.push(`[item] ${item?.name ?? 'Unknown'} used by ${userId}`)
-  return state
+export function useItem(
+  state: BattleState,
+  item: RuntimeItem,
+  userId: string,
+  targetIds?: string[],
+): UseResult {
+  return executeAction(state, item, userId, targetIds)
 }
 
-export function endTurn(state: BattleState) {
+export function endTurn(state: BattleState): BattleState {
+  if (state.ended) {
+    return state
+  }
+
+  const currentActorId = state.order[state.current]
+  const actor = currentActorId ? state.actors[currentActorId] : undefined
+  if (actor) {
+    pushLog(state, `${actor.name} ended their turn.`)
+    tickEndOfTurn(state, actor.id)
+    tickCooldowns(state, actor.id)
+    evaluateOutcome(state)
+    if (state.ended) {
+      return state
+    }
+  }
+
   state.current = (state.current + 1) % (state.order.length || 1)
-  if (state.current === 0) state.turn += 1
+  if (state.current === 0) {
+    state.turn += 1
+    pushLog(state, `Turn ${state.turn} begins.`)
+  }
   return state
+}
+
+type ActionFormulaContext = FormulaContext & { state: BattleState; action: RuntimeAction }
+
+type DamageOptions = {
+  crit?: boolean
+  element?: string
+}
+
+type ItemCost = { id: string; qty: number; consume: boolean }
+
+function executeAction(
+  state: BattleState,
+  action: RuntimeAction,
+  userId: string,
+  providedTargetIds?: string[],
+): UseResult {
+  if (state.ended) {
+    pushLog(state, 'The battle is already over.')
+    return { ok: false, log: state.log, state }
+  }
+
+  const user = state.actors[userId]
+  if (!user) {
+    pushLog(state, `Unknown actor ${userId} tried to use ${action.name}.`)
+    return { ok: false, log: state.log, state }
+  }
+
+  if (!user.alive) {
+    pushLog(state, `${user.name} cannot act while defeated.`)
+    return { ok: false, log: state.log, state }
+  }
+
+  if (!checkCooldownReady(state, user, action)) {
+    return { ok: false, log: state.log, state }
+  }
+
+  if (!checkChargesAvailable(state, user, action)) {
+    return { ok: false, log: state.log, state }
+  }
+
+  const itemCosts = collectItemCosts(action)
+  if (!checkItemAvailability(state, itemCosts, action)) {
+    return { ok: false, log: state.log, state }
+  }
+
+  if (!payResourceCost(user, action.costs?.sta ?? 0, 'sta', state, action.name)) {
+    return { ok: false, log: state.log, state }
+  }
+
+  if (!payResourceCost(user, action.costs?.mp ?? 0, 'mp', state, action.name)) {
+    return { ok: false, log: state.log, state }
+  }
+
+  const baseTargetIds =
+    providedTargetIds && providedTargetIds.length
+      ? providedTargetIds
+      : resolveTargets(state, normalizeSelector(action.targeting), userId)
+
+  const baseTargets = filterActors(state, baseTargetIds)
+
+  if (baseTargets.length === 0) {
+    pushLog(state, `${action.name} has no valid targets.`)
+  }
+
+  applyItemCosts(state, itemCosts)
+  startCooldown(state, user, action)
+  consumeCharge(state, user, action)
+
+  pushLog(state, `${user.name} used ${action.name}.`)
+
+  for (const effect of action.effects ?? []) {
+    const selector = effect.selector ?? action.targeting
+    const targets = effect.selector
+      ? filterActors(state, resolveTargets(state, normalizeSelector(selector), userId))
+      : baseTargets
+
+    if (targets.length === 0) {
+      continue
+    }
+
+    for (const target of targets) {
+      applyEffect(state, action, effect, user, target)
+      if (state.ended) {
+        break
+      }
+    }
+    if (state.ended) {
+      break
+    }
+  }
+
+  evaluateOutcome(state)
+  return { ok: true, log: state.log, state }
+}
+
+function normalizeSelector(selector: RuntimeTargetSelector): RuntimeTargetSelector {
+  const includeDead = selector.includeDead ?? false
+  const count = selector.count ?? (selector.mode === 'random' ? 1 : undefined)
+  return { ...selector, includeDead, count }
+}
+
+function filterActors(state: BattleState, ids: string[]): Actor[] {
+  return ids
+    .map((id) => state.actors[id])
+    .filter((actor): actor is Actor => Boolean(actor))
+}
+
+function payResourceCost(
+  actor: Actor,
+  cost: number,
+  resource: 'sta' | 'mp',
+  state: BattleState,
+  actionName: string,
+): boolean {
+  const amount = Math.max(0, cost ?? 0)
+  if (amount === 0) {
+    return true
+  }
+
+  const key = resource
+  const current = actor.stats[key]
+  if (current < amount) {
+    pushLog(
+      state,
+      `Not enough ${resource.toUpperCase()} to use ${actionName} (need ${amount}, have ${current}).`,
+    )
+    return false
+  }
+
+  actor.stats[key] = current - amount
+  return true
+}
+
+function applyEffect(
+  state: BattleState,
+  action: RuntimeAction,
+  effect: RuntimeEffect,
+  user: Actor,
+  target: Actor,
+) {
+  if (effect.onlyIf && !matchesFilter(target, effect.onlyIf)) {
+    return
+  }
+
+  const ctx: ActionFormulaContext = { state, action }
+  const base = resolveValue(effect.value.resolve, effect.value.kind, user, target, ctx, effect, action)
+  const amount = base.kind === 'none' ? 0 : base.amount
+  const ruleCtx: RuleContext = { state, action, effect }
+
+  switch (effect.kind) {
+    case 'damage': {
+      if (effect.canMiss) {
+        const roll = nextRandom(state)
+        const chance = clamp(hitChance(user, target, ruleCtx), 0, 1)
+        if (roll > chance) {
+          pushLog(state, `${user.name}'s ${action.name} missed ${target.name}.`)
+          return
+        }
+      }
+
+      const element = effect.element ?? action.element
+      let finalAmount = amount * elementMult(element, target) * tagResistMult(target)
+      let crit = false
+
+      if (effect.canCrit) {
+        const chance = clamp(critChance(user, target, ruleCtx), 0, 1)
+        const roll = nextRandom(state)
+        if (roll < chance) {
+          const { CRIT_MULT } = CONFIG().balance
+          finalAmount *= CRIT_MULT
+          crit = true
+        }
+      }
+
+      const dealt = applyDamage(state, user, target, finalAmount, { crit, element })
+      triggerStatusHooks(state, user, 'onDealDamage', {
+        other: target,
+        amount: dealt,
+        element,
+      })
+      triggerStatusHooks(state, target, 'onTakeDamage', {
+        other: user,
+        amount: dealt,
+        element,
+      })
+      break
+    }
+    case 'heal':
+      applyHeal(state, user, target, amount)
+      break
+    case 'resource':
+      if (effect.resource) {
+        applyResource(state, user, target, amount, effect.resource)
+      }
+      break
+    case 'applyStatus': {
+      if (!effect.statusId) {
+        pushLog(state, `${action.name} tried to apply a status with no ID.`)
+        break
+      }
+
+      if (effect.canMiss) {
+        const roll = nextRandom(state)
+        const chance = clamp(hitChance(user, target, ruleCtx), 0, 1)
+        if (roll > chance) {
+          pushLog(state, `${user.name}'s ${action.name} failed to affect ${target.name}.`)
+          return
+        }
+      }
+
+      const turns = effect.statusTurns ?? Math.round(amount)
+      const stacks = normalizeStacks(amount)
+      applyStatus(state, target.id, effect.statusId, turns, { stacks, sourceId: user.id })
+      break
+    }
+    case 'cleanseStatus': {
+      const removed = cleanseStatuses(state, target, effect.cleanseTags)
+      if (removed.length === 0) {
+        pushLog(state, `${action.name} could not find any statuses to cleanse on ${target.name}.`)
+      } else {
+        pushLog(state, `${user.name} cleansed ${removed.join(', ')} from ${target.name}.`)
+      }
+      break
+    }
+    case 'shield': {
+      const shieldId = effect.shieldId ?? effect.statusId ?? action.id
+      if (!shieldId) {
+        pushLog(state, `${action.name} tried to grant a shield without an identifier.`)
+        break
+      }
+      const total = Math.max(0, amount)
+      const element = effect.element ?? action.element
+      if (total <= 0) {
+        grantShield(state, target, shieldId, 0, element, { replace: true })
+        pushLog(state, `${target.name}'s ${shieldId} faded.`)
+      } else {
+        const remaining = grantShield(state, target, shieldId, total, element)
+        pushLog(state, `${user.name} granted ${target.name} a ${shieldId} shield (${Math.round(remaining)} HP).`)
+      }
+      break
+    }
+    case 'taunt': {
+      const turns = effect.statusTurns ?? Math.max(1, Math.round(amount))
+      applyTaunt(state, target.id, user.id, turns)
+      if (turns > 0) {
+        pushLog(state, `${target.name} is taunted by ${user.name} for ${turns} turn(s).`)
+      } else {
+        pushLog(state, `${target.name} is no longer taunted.`)
+      }
+      break
+    }
+    case 'revive': {
+      const healAmount = Math.max(0, amount)
+      if (!target.alive) {
+        const restored = clamp(Math.max(1, Math.round(healAmount || target.stats.maxHp * 0.25)), 1, target.stats.maxHp)
+        target.stats.hp = restored
+        target.alive = true
+        pushLog(state, `${user.name} revived ${target.name} (${restored} HP).`)
+      } else {
+        applyHeal(state, user, target, healAmount)
+      }
+      break
+    }
+    case 'flee': {
+      state.ended = { reason: 'fled' }
+      pushLog(state, `${user.name} fled the battle!`)
+      break
+    }
+    case 'modifyStat': {
+      if (!effect.stat) {
+        pushLog(state, `${action.name} tried to modify a stat without specifying one.`)
+        break
+      }
+      const delta = Math.round(amount)
+      modifyStat(target, effect.stat, delta, state, user.name, action.name)
+      break
+    }
+    default:
+      // unsupported kinds will be ignored in this phase
+      break
+  }
+}
+
+function resolveValue(
+  resolver: ValueResolver,
+  kind: RuntimeEffect['value']['kind'],
+  user: Actor,
+  target: Actor,
+  ctx: ActionFormulaContext,
+  effect: RuntimeEffect,
+  action: RuntimeAction,
+): { kind: 'number'; amount: number } | { kind: 'none' } {
+  try {
+    const resolved = resolver(user, target, ctx)
+    const amount = normalizeAmount(resolved, kind, target, effect)
+    return { kind: 'number', amount }
+  } catch (error) {
+    pushLog(
+      ctx.state,
+      `Failed to resolve value for ${action.name}: ${(error as Error).message}`,
+    )
+    return { kind: 'none' }
+  }
+}
+
+function normalizeAmount(
+  value: number,
+  kind: RuntimeEffect['value']['kind'],
+  target: Actor,
+  effect: RuntimeEffect,
+): number {
+  const safe = Number.isFinite(value) ? value : 0
+  if (kind === 'percent') {
+    if (effect.kind === 'resource' && effect.resource) {
+      const [, maxKey] = resourceKeys(effect.resource)
+      const maxValue = target.stats[maxKey]
+      return safe * maxValue
+    }
+    return safe * target.stats.maxHp
+  }
+  return safe
+}
+
+function applyDamage(
+  state: BattleState,
+  user: Actor,
+  target: Actor,
+  amount: number,
+  options: DamageOptions = {},
+): number {
+  if (!target.alive) {
+    return 0
+  }
+
+  let pending = Math.max(0, amount)
+  const shieldResult = absorbDamageWithShields(state, target, pending, options.element)
+  for (const log of shieldResult.logs) {
+    pushLog(state, log)
+  }
+  pending = shieldResult.remaining
+
+  if (pending <= 0) {
+    if (shieldResult.absorbed > 0) {
+      pushLog(state, `${user.name}'s attack was absorbed by ${target.name}'s shields.`)
+    } else {
+      pushLog(state, `${user.name}'s attack dealt no damage to ${target.name}.`)
+    }
+    return 0
+  }
+
+  const before = target.stats.hp
+  const after = Math.max(0, before - pending)
+  target.stats.hp = after
+  if (after <= 0) {
+    target.alive = false
+  }
+  const diff = before - after
+  let entry = `${user.name} hit ${target.name} for ${Math.round(diff)} damage.`
+  if (options.crit) {
+    entry += ' Critical hit!'
+  }
+  if (after <= 0) {
+    entry += ` ${target.name} was defeated.`
+  }
+  pushLog(state, entry)
+  return diff
+}
+
+function applyHeal(state: BattleState, user: Actor, target: Actor, amount: number) {
+  const heal = Math.max(0, amount)
+  const before = target.stats.hp
+  const after = Math.min(target.stats.maxHp, before + heal)
+  target.stats.hp = after
+  if (after > 0) {
+    target.alive = true
+  }
+  const diff = after - before
+  pushLog(state, `${user.name} healed ${target.name} for ${Math.round(diff)} HP.`)
+}
+
+function applyResource(
+  state: BattleState,
+  user: Actor,
+  target: Actor,
+  amount: number,
+  resource: Resource,
+) {
+  const [currentKey, maxKey] = resourceKeys(resource)
+  const before = target.stats[currentKey]
+  const max = target.stats[maxKey]
+  const after = clamp(before + amount, 0, max)
+  target.stats[currentKey] = after
+  const diff = after - before
+  const label = resource.toUpperCase()
+  if (diff === 0) {
+    pushLog(state, `${user.name} affected ${target.name}'s ${label}, but nothing changed.`)
+  } else if (diff > 0) {
+    pushLog(state, `${user.name} restored ${Math.round(diff)} ${label} to ${target.name}.`)
+  } else {
+    pushLog(state, `${user.name} drained ${Math.round(Math.abs(diff))} ${label} from ${target.name}.`)
+  }
+}
+
+function modifyStat(
+  target: Actor,
+  stat: NonNullable<RuntimeEffect['stat']>,
+  delta: number,
+  state: BattleState,
+  sourceName: string,
+  actionName: string,
+) {
+  let finalValue = 0
+  switch (stat) {
+    case 'atk':
+      target.stats.atk = Math.max(0, target.stats.atk + delta)
+      finalValue = target.stats.atk
+      break
+    case 'def':
+      target.stats.def = Math.max(0, target.stats.def + delta)
+      finalValue = target.stats.def
+      break
+    case 'maxHp':
+      target.stats.maxHp = Math.max(1, target.stats.maxHp + delta)
+      target.stats.hp = clamp(target.stats.hp, 0, target.stats.maxHp)
+      finalValue = target.stats.maxHp
+      break
+    case 'maxSta':
+      target.stats.maxSta = Math.max(0, target.stats.maxSta + delta)
+      target.stats.sta = clamp(target.stats.sta, 0, target.stats.maxSta)
+      finalValue = target.stats.maxSta
+      break
+    case 'maxMp':
+      target.stats.maxMp = Math.max(0, target.stats.maxMp + delta)
+      target.stats.mp = clamp(target.stats.mp, 0, target.stats.maxMp)
+      finalValue = target.stats.maxMp
+      break
+    default:
+      return
+  }
+
+  if (delta === 0) {
+    pushLog(state, `${sourceName}'s ${actionName} left ${target.name}'s ${formatStatLabel(stat)} unchanged.`)
+  } else {
+    const sign = delta > 0 ? '+' : ''
+    pushLog(
+      state,
+      `${sourceName}'s ${actionName} changed ${target.name}'s ${formatStatLabel(stat)} by ${sign}${delta} (now ${Math.round(finalValue)}).`,
+    )
+  }
+}
+
+function normalizeStacks(amount: number): number {
+  if (!Number.isFinite(amount)) {
+    return 1
+  }
+  const rounded = Math.round(Math.abs(amount))
+  return Math.max(1, rounded)
+}
+
+function formatStatLabel(stat: NonNullable<RuntimeEffect['stat']>): string {
+  switch (stat) {
+    case 'atk':
+      return 'ATK'
+    case 'def':
+      return 'DEF'
+    case 'maxHp':
+      return 'Max HP'
+    case 'maxSta':
+      return 'Max STA'
+    case 'maxMp':
+      return 'Max MP'
+    default:
+      return stat
+  }
+}
+
+function resourceKeys(resource: Resource): ['hp' | 'sta' | 'mp', 'maxHp' | 'maxSta' | 'maxMp'] {
+  switch (resource) {
+    case 'sta':
+      return ['sta', 'maxSta']
+    case 'mp':
+      return ['mp', 'maxMp']
+    case 'hp':
+    default:
+      return ['hp', 'maxHp']
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+function nextRandom(state: BattleState): number {
+  const seed = state.rngSeed >>> 0
+  const next = (Math.imul(seed, RNG_A) + RNG_C) >>> 0
+  state.rngSeed = next
+  return next / RNG_M
+}
+
+function evaluateOutcome(state: BattleState) {
+  if (state.ended) {
+    return
+  }
+  const enemiesAlive = state.sideEnemy.some((id) => state.actors[id]?.alive)
+  if (!enemiesAlive) {
+    state.ended = { reason: 'victory' }
+    pushLog(state, 'Victory!')
+    return
+  }
+  const playersAlive = state.sidePlayer.some((id) => state.actors[id]?.alive)
+  if (!playersAlive) {
+    state.ended = { reason: 'defeat' }
+    pushLog(state, 'Defeat...')
+  }
+}
+
+function matchesFilter(actor: Actor, filter: Filter): boolean {
+  if (filter.all && !filter.all.every((inner) => matchesFilter(actor, inner))) {
+    return false
+  }
+  if (filter.any && !filter.any.some((inner) => matchesFilter(actor, inner))) {
+    return false
+  }
+  if (filter.not && matchesFilter(actor, filter.not)) {
+    return false
+  }
+  if (!filter.test) {
+    return true
+  }
+  const { key, op, value } = filter.test
+  switch (key) {
+    case 'hpPct':
+      return compareNumeric(fraction(actor.stats.hp, actor.stats.maxHp), op, value)
+    case 'staPct':
+      return compareNumeric(fraction(actor.stats.sta, actor.stats.maxSta), op, value)
+    case 'mpPct':
+      return compareNumeric(fraction(actor.stats.mp, actor.stats.maxMp), op, value)
+    case 'atk':
+      return compareNumeric(actor.stats.atk, op, value)
+    case 'def':
+      return compareNumeric(actor.stats.def, op, value)
+    case 'lv':
+      return compareNumeric(actor.stats.lv, op, value)
+    case 'hasStatus':
+      return compareSet(actor.statuses.map((entry) => entry.id), op, value)
+    case 'tag':
+      return compareSet(actor.tags ?? [], op, value)
+    case 'clazz':
+      return compareValue(actor.clazz ?? null, op, value)
+    default:
+      return false
+  }
+}
+
+function compareNumeric(actual: number, op: ConditionOp, expected: unknown): boolean {
+  if (op === 'in' || op === 'notIn') {
+    const values = Array.isArray(expected) ? expected : [expected]
+    const parsed = values
+      .map((value) => (typeof value === 'number' ? value : Number(value)))
+      .filter((num) => Number.isFinite(num))
+    const has = parsed.some((num) => num === actual)
+    return op === 'in' ? has : !has
+  }
+
+  const expectedNumber = typeof expected === 'number' ? expected : Number(expected)
+  if (!Number.isFinite(expectedNumber)) {
+    return false
+  }
+
+  switch (op) {
+    case 'lt':
+      return actual < expectedNumber
+    case 'lte':
+      return actual <= expectedNumber
+    case 'eq':
+      return actual === expectedNumber
+    case 'gte':
+      return actual >= expectedNumber
+    case 'gt':
+      return actual > expectedNumber
+    case 'ne':
+      return actual !== expectedNumber
+    default:
+      return false
+  }
+}
+
+function compareValue(actual: unknown, op: ConditionOp, expected: unknown): boolean {
+  if (op === 'in' || op === 'notIn') {
+    const values = Array.isArray(expected) ? expected : [expected]
+    const has = values.some((entry) => entry === actual)
+    return op === 'in' ? has : !has
+  }
+  switch (op) {
+    case 'eq':
+      return actual === expected
+    case 'ne':
+      return actual !== expected
+    default:
+      return false
+  }
+}
+
+function compareSet(actual: string[], op: ConditionOp, expected: unknown): boolean {
+  const values = Array.isArray(expected) ? expected : [expected]
+  const hasAny = values.some((entry) => actual.includes(entry))
+  if (op === 'in') {
+    return hasAny
+  }
+  if (op === 'notIn') {
+    return !hasAny
+  }
+  if (op === 'eq') {
+    return hasAny
+  }
+  if (op === 'ne') {
+    return !hasAny
+  }
+  return false
+}
+
+function fraction(value: number, max: number): number {
+  if (!Number.isFinite(value) || !Number.isFinite(max) || max <= 0) {
+    return 0
+  }
+  return value / max
+}
+
+function collectItemCosts(action: RuntimeAction): ItemCost[] {
+  const map = new Map<string, { qty: number; consume: boolean }>()
+  const add = (id: string, qty: number, consume: boolean) => {
+    if (!id || qty <= 0) {
+      return
+    }
+    const existing = map.get(id)
+    if (existing) {
+      existing.qty += qty
+      existing.consume = existing.consume || consume
+    } else {
+      map.set(id, { qty, consume })
+    }
+  }
+
+  if (action.type === 'item') {
+    const id = action.costs?.item?.id ?? action.id
+    const qty = action.costs?.item?.qty ?? 1
+    add(id, Math.max(1, Math.round(qty)), action.consumable)
+  } else if (action.costs?.item) {
+    add(action.costs.item.id, Math.max(1, Math.round(action.costs.item.qty ?? 1)), true)
+  }
+
+  return Array.from(map.entries()).map(([id, value]) => ({ id, qty: value.qty, consume: value.consume }))
+}
+
+function checkItemAvailability(state: BattleState, costs: ItemCost[], action: RuntimeAction): boolean {
+  for (const cost of costs) {
+    const entry = state.inventory.find((item) => item.id === cost.id)
+    if (!entry || entry.qty < cost.qty) {
+      pushLog(state, `Missing ${cost.id} x${cost.qty} to use ${action.name}.`)
+      return false
+    }
+  }
+  return true
+}
+
+function applyItemCosts(state: BattleState, costs: ItemCost[]) {
+  for (const cost of costs) {
+    if (!cost.consume) {
+      continue
+    }
+    const entry = state.inventory.find((item) => item.id === cost.id)
+    if (!entry) {
+      continue
+    }
+    entry.qty = Math.max(0, entry.qty - cost.qty)
+    if (entry.qty <= 0) {
+      state.inventory = state.inventory.filter((item) => item !== entry)
+    }
+  }
+}
+
+function checkCooldownReady(state: BattleState, user: Actor, action: RuntimeAction): boolean {
+  const cooldown = Math.max(0, Math.floor(action.costs?.cooldown ?? 0))
+  if (cooldown <= 0) {
+    return true
+  }
+  const remaining = state.cooldowns[user.id]?.[action.id] ?? 0
+  if (remaining > 0) {
+    pushLog(state, `${action.name} is on cooldown for ${remaining} more turn(s).`)
+    return false
+  }
+  return true
+}
+
+function startCooldown(state: BattleState, user: Actor, action: RuntimeAction) {
+  const cooldown = Math.max(0, Math.floor(action.costs?.cooldown ?? 0))
+  if (cooldown <= 0) {
+    return
+  }
+  const map = ensureCooldownMap(state, user.id)
+  map[action.id] = cooldown
+}
+
+function tickCooldowns(state: BattleState, _actorId: string) {
+  for (const map of Object.values(state.cooldowns)) {
+    for (const [actionId, remaining] of Object.entries(map)) {
+      const next = Math.max(0, Math.floor(remaining) - 1)
+      if (next <= 0) {
+        delete map[actionId]
+      } else {
+        map[actionId] = next
+      }
+    }
+  }
+}
+
+function checkChargesAvailable(state: BattleState, user: Actor, action: RuntimeAction): boolean {
+  const maxCharges = Math.max(0, Math.floor(action.costs?.charges ?? 0))
+  if (maxCharges <= 0) {
+    return true
+  }
+  const map = ensureChargeMap(state, user.id)
+  const existing = map[action.id] ?? { remaining: maxCharges, max: maxCharges }
+  map[action.id] = existing
+  if (existing.remaining <= 0) {
+    pushLog(state, `${action.name} has no charges remaining.`)
+    return false
+  }
+  return true
+}
+
+function consumeCharge(state: BattleState, user: Actor, action: RuntimeAction) {
+  const maxCharges = Math.max(0, Math.floor(action.costs?.charges ?? 0))
+  if (maxCharges <= 0) {
+    return
+  }
+  const map = ensureChargeMap(state, user.id)
+  const existing = map[action.id] ?? { remaining: maxCharges, max: maxCharges }
+  map[action.id] = existing
+  if (existing.remaining > 0) {
+    existing.remaining -= 1
+  }
+}
+
+function ensureCooldownMap(
+  state: BattleState,
+  actorId: string,
+): Record<string, number> {
+  const existing = state.cooldowns[actorId]
+  if (existing) {
+    return existing
+  }
+  state.cooldowns[actorId] = {}
+  return state.cooldowns[actorId]
+}
+
+function ensureChargeMap(
+  state: BattleState,
+  actorId: string,
+): Record<string, ChargeState> {
+  const existing = state.charges[actorId]
+  if (existing) {
+    return existing
+  }
+  state.charges[actorId] = {}
+  return state.charges[actorId]
+}
+
+function pushLog(state: BattleState, entry: string) {
+  state.log.push(entry)
 }

--- a/minmmo/src/engine/battle/rules.ts
+++ b/minmmo/src/engine/battle/rules.ts
@@ -1,8 +1,68 @@
+import { CONFIG } from '@config/store'
+import type { RuntimeEffect, RuntimeItem, RuntimeSkill } from '@content/adapters'
+import type { Actor, BattleState } from './types'
 
-export const Rules = {
-  BASE_HIT: 0.85,
-  BASE_CRIT: 0.05,
-  CRIT_MULT: 1.5,
-  DODGE_FLOOR: 0.05,
-  HIT_CEIL: 0.99,
+export interface RuleContext {
+  state: BattleState
+  action: RuntimeSkill | RuntimeItem
+  effect: RuntimeEffect
+}
+
+export function hitChance(user: Actor, target: Actor, _ctx: RuleContext): number {
+  const { balance } = CONFIG()
+  const levelDiff = (user.stats.lv - target.stats.lv) * 0.02
+  const statDiff = (user.stats.atk - target.stats.def) * 0.01
+  const raw = balance.BASE_HIT + levelDiff + statDiff
+  return clamp(raw, balance.DODGE_FLOOR, balance.HIT_CEIL)
+}
+
+export function critChance(user: Actor, target: Actor, _ctx: RuleContext): number {
+  const { balance } = CONFIG()
+  const levelBonus = Math.max(0, user.stats.lv - target.stats.lv) * 0.01
+  const statBonus = Math.max(0, user.stats.atk - target.stats.def) * 0.005
+  const raw = balance.BASE_CRIT + levelBonus + statBonus
+  return clamp(raw, 0, 1)
+}
+
+export function elementMult(element: string | undefined, target: Actor): number {
+  if (!element) {
+    return 1
+  }
+  const { balance } = CONFIG()
+  const table = balance.ELEMENT_MATRIX[element]
+  if (!table) {
+    return 1
+  }
+
+  const tags = target.tags ?? []
+  for (const tag of tags) {
+    const value = table[tag]
+    if (typeof value === 'number') {
+      return value
+    }
+  }
+
+  return typeof table.neutral === 'number' ? table.neutral : 1
+}
+
+export function tagResistMult(target: Actor): number {
+  const { balance } = CONFIG()
+  const resists = balance.RESISTS_BY_TAG
+  if (!target.tags || target.tags.length === 0) {
+    return 1
+  }
+
+  return target.tags.reduce((acc, tag) => {
+    const value = resists[tag]
+    return typeof value === 'number' ? acc * value : acc
+  }, 1)
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min
+  }
+  if (value < min) return min
+  if (value > max) return max
+  return value
 }

--- a/minmmo/src/engine/battle/state.ts
+++ b/minmmo/src/engine/battle/state.ts
@@ -31,6 +31,10 @@ export function createState(p: Params): BattleState {
     order,
     current: (('current' in p) && p.current!=null) ? p.current! : 0,
     turn:    (('turn' in p) && p.turn!=null)       ? p.turn!    : 1,
-    log:     (('log' in p) && p.log)               ? p.log!.slice() : []
+    log:     (('log' in p) && p.log)               ? p.log!.slice() : [],
+    cooldowns: {},
+    charges: {},
+    shields: {},
+    taunts: {},
   }
 }

--- a/minmmo/src/engine/battle/status.ts
+++ b/minmmo/src/engine/battle/status.ts
@@ -1,11 +1,598 @@
+import type {
+  FormulaContext,
+  RuntimeEffect,
+  RuntimeStatusTemplate,
+  ValueResolver,
+} from '@content/adapters'
+import { Statuses } from '@content/registry'
+import { elementMult, tagResistMult } from './rules'
+import type { Actor, BattleState, Status } from './types'
 
-import type { BattleState } from './types'
-
-export function tickEndOfTurn(state: BattleState, actorOrId: string | { statuses:any[] }) {
-  const a: any = typeof actorOrId === 'string' ? (state.actors as any)[actorOrId] : actorOrId
-  if (!a) return
-  if (!Array.isArray(a.statuses)) a.statuses = []
-  a.statuses = a.statuses
-    .map((s:any)=>({ ...s, turns: (s.turns ?? 0) - 1 }))
-    .filter((s:any)=> (s.turns ?? 0) > 0)
+export interface StatusApplyOptions {
+  stacks?: number
+  sourceId?: string
 }
+
+type StatusHookName = keyof RuntimeStatusTemplate['hooks']
+
+interface ActiveStatus extends Status {
+  stacks: number
+  sourceId?: string
+}
+
+interface StatusEventContext {
+  kind: StatusHookName
+  amount?: number
+  element?: string
+  otherId?: string
+}
+
+interface StatusFormulaContext extends FormulaContext {
+  state: BattleState
+  status: RuntimeStatusTemplate
+  entry: ActiveStatus
+  source: Actor
+  event?: StatusEventContext
+}
+
+interface HookOptions {
+  other?: Actor
+  amount?: number
+  element?: string
+}
+
+interface ShieldImpact {
+  id: string
+  absorbed: number
+}
+
+export function applyStatus(
+  state: BattleState,
+  targetId: string,
+  statusId: string,
+  turns: number,
+  options: StatusApplyOptions = {},
+): void {
+  const target = state.actors[targetId]
+  if (!target) {
+    pushLog(state, `Tried to apply unknown status ${statusId} to missing actor ${targetId}.`)
+    return
+  }
+
+  const template = Statuses()[statusId]
+  if (!template) {
+    pushLog(state, `Status ${statusId} is not defined.`)
+    return
+  }
+
+  const duration = resolveDuration(turns, template)
+  if (duration <= 0) {
+    pushLog(state, `${template.name ?? template.id} had no effect.`)
+    return
+  }
+
+  const stacksToAdd = Math.max(1, Math.floor(options.stacks ?? 1))
+  const active = ensureStatuses(target)
+  const existingIndex = active.findIndex((entry) => entry.id === statusId)
+  const name = template.name ?? template.id
+
+  const maxStacks = template.maxStacks ?? Infinity
+  const clampStacks = (value: number) => clamp(value, 1, maxStacks)
+
+  if (existingIndex >= 0) {
+    const existing = active[existingIndex]
+    switch (template.stackRule) {
+      case 'ignore':
+        pushLog(state, `${name} is already affecting ${target.name}.`)
+        return
+      case 'stackCount':
+        existing.stacks = clampStacks(existing.stacks + stacksToAdd)
+        existing.turns = duration
+        break
+      case 'stackMagnitude':
+        existing.stacks = clampStacks(existing.stacks + stacksToAdd)
+        existing.turns = duration
+        break
+      case 'renew':
+      default:
+        existing.turns = duration
+        existing.stacks = clampStacks(stacksToAdd)
+        break
+    }
+    if (options.sourceId) {
+      existing.sourceId = options.sourceId
+    }
+    syncStatusModifiers(state, target, existing, template)
+    pushLog(state, `${target.name}'s ${name} was refreshed (${existing.turns} turns).`)
+    runHookForEntry(state, target, template, existing, 'onApply', {
+      other: resolveSourceActor(state, existing.sourceId) ?? target,
+    })
+    return
+  }
+
+  const entry: ActiveStatus = {
+    id: statusId,
+    turns: duration,
+    stacks: clampStacks(stacksToAdd),
+  }
+  if (options.sourceId) {
+    entry.sourceId = options.sourceId
+  }
+
+  active.push(entry)
+  syncStatusModifiers(state, target, entry, template)
+  pushLog(state, `${target.name} is afflicted by ${name} for ${duration} turns.`)
+  runHookForEntry(state, target, template, entry, 'onApply', {
+    other: resolveSourceActor(state, entry.sourceId) ?? target,
+  })
+}
+
+export function tickEndOfTurn(state: BattleState, actorOrId: string | Actor): void {
+  const actor = typeof actorOrId === 'string' ? state.actors[actorOrId] : actorOrId
+  if (!actor) {
+    return
+  }
+
+  const statuses = ensureStatuses(actor)
+  if (statuses.length === 0 && !state.taunts[actor.id]) {
+    return
+  }
+
+  const next: ActiveStatus[] = []
+  for (const entry of statuses) {
+    const template = Statuses()[entry.id]
+    if (!template) {
+      continue
+    }
+
+    runHookForEntry(state, actor, template, entry, 'onTurnEnd', {
+      other: resolveSourceActor(state, entry.sourceId) ?? actor,
+    })
+
+    entry.turns -= 1
+    if (entry.turns > 0) {
+      next.push(entry)
+    } else {
+      pushLog(state, `${template.name ?? template.id} expired on ${actor.name}.`)
+      expireStatus(state, actor, template, entry)
+    }
+  }
+
+  actor.statuses = next
+  tickTaunt(state, actor)
+}
+
+export function triggerStatusHooks(
+  state: BattleState,
+  actor: Actor,
+  hook: StatusHookName,
+  options: HookOptions = {},
+): void {
+  const statuses = ensureStatuses(actor)
+  for (const entry of statuses) {
+    const template = Statuses()[entry.id]
+    if (!template) {
+      continue
+    }
+    runHookForEntry(state, actor, template, entry, hook, options)
+  }
+}
+
+export function grantShield(
+  state: BattleState,
+  actor: Actor,
+  shieldId: string,
+  amount: number,
+  element?: string,
+  { replace = false }: { replace?: boolean } = {},
+): number {
+  const map = ensureShieldMap(state, actor.id)
+  const safe = Math.max(0, Math.round(Number.isFinite(amount) ? amount : 0))
+
+  if (safe <= 0 && replace) {
+    delete map[shieldId]
+    return 0
+  }
+
+  const existing = map[shieldId] ?? { id: shieldId, hp: 0 as number, element }
+  if (replace) {
+    existing.hp = safe
+  } else {
+    existing.hp = Math.max(0, existing.hp + safe)
+  }
+  if (element !== undefined) {
+    existing.element = element
+  }
+  map[shieldId] = existing
+  return existing.hp
+}
+
+export function absorbDamageWithShields(
+  state: BattleState,
+  actor: Actor,
+  amount: number,
+  element?: string,
+): { remaining: number; absorbed: number; logs: string[] } {
+  const map = state.shields[actor.id]
+  let remaining = Math.max(0, amount)
+  if (!map || remaining <= 0) {
+    return { remaining, absorbed: 0, logs: [] }
+  }
+
+  const logs: string[] = []
+  const impacts: ShieldImpact[] = []
+  for (const [shieldId, shield] of Object.entries(map)) {
+    if (remaining <= 0) {
+      break
+    }
+    if (shield.hp <= 0) {
+      delete map[shieldId]
+      continue
+    }
+    const absorbed = Math.min(remaining, shield.hp)
+    shield.hp -= absorbed
+    remaining -= absorbed
+    impacts.push({ id: shieldId, absorbed })
+    if (shield.hp <= 0) {
+      delete map[shieldId]
+      logs.push(`${actor.name}'s ${shieldId} shattered.`)
+    }
+  }
+
+  for (const impact of impacts) {
+    if (impact.absorbed <= 0) {
+      continue
+    }
+    logs.unshift(`${actor.name}'s ${impact.id} absorbed ${Math.round(impact.absorbed)} damage.`)
+  }
+
+  const absorbedTotal = Math.max(0, amount - remaining)
+  return { remaining, absorbed: absorbedTotal, logs }
+}
+
+export function cleanseStatuses(
+  state: BattleState,
+  actor: Actor,
+  tags?: string[],
+): string[] {
+  const statuses = ensureStatuses(actor)
+  if (statuses.length === 0) {
+    return []
+  }
+
+  const tagSet = tags && tags.length ? new Set(tags) : undefined
+  const kept: ActiveStatus[] = []
+  const removedNames: string[] = []
+
+  for (const entry of statuses) {
+    const template = Statuses()[entry.id]
+    if (!template) {
+      continue
+    }
+    const match = !tagSet
+      ? true
+      : (template.tags ?? []).some((tag) => tagSet.has(tag))
+    if (match) {
+      removedNames.push(template.name ?? template.id)
+      expireStatus(state, actor, template, entry)
+    } else {
+      kept.push(entry)
+    }
+  }
+
+  actor.statuses = kept
+  return removedNames
+}
+
+export function applyTaunt(
+  state: BattleState,
+  targetId: string,
+  sourceId: string,
+  turns: number,
+): void {
+  const safeTurns = Math.max(0, Math.floor(Number.isFinite(turns) ? turns : 0))
+  if (safeTurns <= 0) {
+    delete state.taunts[targetId]
+    return
+  }
+  state.taunts[targetId] = { sourceId, turns: safeTurns }
+}
+
+function tickTaunt(state: BattleState, actor: Actor) {
+  const taunt = state.taunts[actor.id]
+  if (!taunt) {
+    return
+  }
+  taunt.turns -= 1
+  if (taunt.turns <= 0) {
+    delete state.taunts[actor.id]
+    pushLog(state, `${actor.name} is no longer taunted.`)
+  }
+}
+
+function runHookForEntry(
+  state: BattleState,
+  actor: Actor,
+  template: RuntimeStatusTemplate,
+  entry: ActiveStatus,
+  hook: StatusHookName,
+  options: HookOptions = {},
+) {
+  const effects = template.hooks?.[hook] ?? []
+  if (effects.length === 0) {
+    return
+  }
+
+  const owner = actor
+  const other = options.other ?? actor
+  const source =
+    hook === 'onTurnEnd' || hook === 'onTurnStart' || hook === 'onApply' || hook === 'onExpire'
+      ? resolveSourceActor(state, entry.sourceId) ?? owner
+      : owner
+
+  const target =
+    hook === 'onDealDamage'
+      ? owner
+      : hook === 'onTakeDamage'
+        ? other
+        : owner
+
+  const ctx: StatusFormulaContext = {
+    state,
+    status: template,
+    entry,
+    source,
+    event: {
+      kind: hook,
+      amount: options.amount,
+      element: options.element,
+      otherId: other.id,
+    },
+  }
+
+  for (const effect of effects) {
+    applyHookEffect(state, template, effect, source, target, ctx)
+  }
+}
+
+function expireStatus(
+  state: BattleState,
+  actor: Actor,
+  template: RuntimeStatusTemplate,
+  entry: ActiveStatus,
+) {
+  clearStatusShield(state, actor, template)
+  runHookForEntry(state, actor, template, entry, 'onExpire', {
+    other: resolveSourceActor(state, entry.sourceId) ?? actor,
+  })
+}
+
+function syncStatusModifiers(
+  state: BattleState,
+  actor: Actor,
+  entry: ActiveStatus,
+  template: RuntimeStatusTemplate,
+) {
+  const shield = template.modifiers?.shield
+  if (shield) {
+    const total = (Number.isFinite(shield.hp) ? shield.hp : 0) * entry.stacks
+    grantShield(state, actor, shield.id ?? template.id, total, shield.element, { replace: true })
+  } else if (template.modifiers?.shield === null) {
+    clearStatusShield(state, actor, template)
+  }
+}
+
+function clearStatusShield(
+  state: BattleState,
+  actor: Actor,
+  template: RuntimeStatusTemplate,
+) {
+  const shieldId = template.modifiers?.shield?.id ?? template.id
+  const map = state.shields[actor.id]
+  if (!map) {
+    return
+  }
+  delete map[shieldId]
+}
+
+function resolveEffectValue(
+  effect: RuntimeEffect,
+  user: Actor,
+  target: Actor,
+  ctx: StatusFormulaContext,
+): { kind: 'number'; amount: number } | { kind: 'none' } {
+  const resolver: ValueResolver = effect.value.resolve
+  try {
+    const raw = resolver(user, target, ctx)
+    const amount = normalizeAmount(raw, effect.value.kind, target, effect)
+    return { kind: 'number', amount }
+  } catch (error) {
+    pushLog(
+      ctx.state,
+      `Status ${ctx.status.name ?? ctx.status.id} failed to resolve value: ${(error as Error).message}`,
+    )
+    return { kind: 'none' }
+  }
+}
+
+function normalizeAmount(
+  value: number,
+  kind: RuntimeEffect['value']['kind'],
+  target: Actor,
+  effect: RuntimeEffect,
+): number {
+  const safe = Number.isFinite(value) ? value : 0
+  if (kind === 'percent') {
+    if (effect.kind === 'resource' && effect.resource) {
+      const [, maxKey] = resourceKeys(effect.resource)
+      const maxValue = target.stats[maxKey]
+      return safe * maxValue
+    }
+    return safe * target.stats.maxHp
+  }
+  return safe
+}
+
+function applyHookEffect(
+  state: BattleState,
+  template: RuntimeStatusTemplate,
+  effect: RuntimeEffect,
+  source: Actor,
+  target: Actor,
+  ctx: StatusFormulaContext,
+) {
+  if (!SUPPORTED_KINDS.has(effect.kind)) {
+    return
+  }
+
+  const resolved = resolveEffectValue(effect, source, target, ctx)
+  if (resolved.kind === 'none') {
+    return
+  }
+
+  const amount = resolved.amount
+  switch (effect.kind) {
+    case 'damage': {
+      const element = effect.element ?? template.modifiers?.shield?.element
+      const finalAmount = amount * elementMult(element, target) * tagResistMult(target)
+      applyStatusDamage(state, template, target, finalAmount)
+      break
+    }
+    case 'heal':
+      applyStatusHeal(state, template, target, amount)
+      break
+    case 'resource':
+      if (effect.resource) {
+        applyStatusResource(state, template, target, amount, effect.resource)
+      }
+      break
+    default:
+      break
+  }
+}
+
+function applyStatusDamage(state: BattleState, template: RuntimeStatusTemplate, target: Actor, amount: number) {
+  if (!target.alive) {
+    return
+  }
+  const dmg = Math.max(0, amount)
+  if (dmg <= 0) {
+    return
+  }
+
+  const before = target.stats.hp
+  const after = Math.max(0, before - dmg)
+  target.stats.hp = after
+  if (after <= 0) {
+    target.alive = false
+  }
+  const diff = before - after
+  const label = template.name ?? template.id
+  let entry = `${target.name} suffers ${Math.round(diff)} damage from ${label}.`
+  if (!target.alive) {
+    entry += ` ${target.name} was defeated.`
+  }
+  pushLog(state, entry)
+}
+
+function applyStatusHeal(state: BattleState, template: RuntimeStatusTemplate, target: Actor, amount: number) {
+  const heal = Math.max(0, amount)
+  if (heal <= 0) {
+    return
+  }
+  const before = target.stats.hp
+  const after = Math.min(target.stats.maxHp, before + heal)
+  target.stats.hp = after
+  if (after > 0) {
+    target.alive = true
+  }
+  const diff = after - before
+  const label = template.name ?? template.id
+  pushLog(state, `${target.name} recovers ${Math.round(diff)} HP from ${label}.`)
+}
+
+function applyStatusResource(
+  state: BattleState,
+  template: RuntimeStatusTemplate,
+  target: Actor,
+  amount: number,
+  resource: 'hp' | 'sta' | 'mp',
+) {
+  const [currentKey, maxKey] = resourceKeys(resource)
+  const before = target.stats[currentKey]
+  const max = target.stats[maxKey]
+  const after = clamp(before + amount, 0, max)
+  target.stats[currentKey] = after
+  const diff = after - before
+  const label = template.name ?? template.id
+  if (diff === 0) {
+    pushLog(state, `${label} affected ${target.name}'s ${resource.toUpperCase()}, but nothing changed.`)
+  } else if (diff > 0) {
+    pushLog(state, `${target.name} gains ${Math.round(diff)} ${resource.toUpperCase()} from ${label}.`)
+  } else {
+    pushLog(state, `${target.name} loses ${Math.round(Math.abs(diff))} ${resource.toUpperCase()} from ${label}.`)
+  }
+}
+
+function resolveDuration(turns: number, template: RuntimeStatusTemplate): number {
+  const explicit = Number.isFinite(turns) ? Math.floor(turns) : NaN
+  if (explicit && explicit > 0) {
+    return explicit
+  }
+  const fallback = template.durationTurns
+  if (fallback == null) {
+    return 0
+  }
+  return Math.max(0, Math.floor(fallback))
+}
+
+function ensureStatuses(actor: Actor): ActiveStatus[] {
+  if (!Array.isArray(actor.statuses)) {
+    actor.statuses = []
+  }
+  actor.statuses = actor.statuses.map((entry) => ({
+    id: entry.id,
+    turns: entry.turns,
+    stacks: Math.max(1, entry.stacks ?? 1),
+    sourceId: (entry as ActiveStatus).sourceId,
+  }))
+  return actor.statuses as ActiveStatus[]
+}
+
+function resolveSourceActor(state: BattleState, sourceId: string | undefined): Actor | undefined {
+  if (!sourceId) {
+    return undefined
+  }
+  return state.actors[sourceId]
+}
+
+function ensureShieldMap(state: BattleState, actorId: string): Record<string, { id: string; hp: number; element?: string }> {
+  const existing = state.shields[actorId]
+  if (existing) {
+    return existing
+  }
+  state.shields[actorId] = {}
+  return state.shields[actorId]
+}
+
+function resourceKeys(resource: 'hp' | 'sta' | 'mp'): ['hp' | 'sta' | 'mp', 'maxHp' | 'maxSta' | 'maxMp'] {
+  switch (resource) {
+    case 'sta':
+      return ['sta', 'maxSta']
+    case 'mp':
+      return ['mp', 'maxMp']
+    case 'hp':
+    default:
+      return ['hp', 'maxHp']
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+function pushLog(state: BattleState, message: string) {
+  state.log.push(message)
+}
+
+const SUPPORTED_KINDS = new Set<RuntimeEffect['kind']>(['damage', 'heal', 'resource'])

--- a/minmmo/src/engine/battle/targeting.ts
+++ b/minmmo/src/engine/battle/targeting.ts
@@ -1,9 +1,302 @@
 
-import type { BattleState, Actor } from './types'
+import type {
+  CompareKey,
+  ConditionOp,
+  Filter,
+  TargetSelector,
+} from '@config/schema'
+
+import type { Actor, BattleState } from './types'
+
+const RNG_A = 1664525
+const RNG_C = 1013904223
+const RNG_M = 0x100000000
 
 export function getEnemies(state: BattleState): Actor[] {
-  return (state.sideEnemy ?? []).map(id => state.actors[id]).filter(Boolean) as Actor[]
+  return (state.sideEnemy ?? []).map((id) => state.actors[id]).filter(Boolean) as Actor[]
 }
+
 export function getAllies(state: BattleState): Actor[] {
-  return (state.sidePlayer ?? []).map(id => state.actors[id]).filter(Boolean) as Actor[]
+  return (state.sidePlayer ?? []).map((id) => state.actors[id]).filter(Boolean) as Actor[]
+}
+
+export function resolveTargets(
+  state: BattleState,
+  selector: TargetSelector,
+  userId: string,
+): string[] {
+  const user = state.actors[userId]
+  if (!user) {
+    return []
+  }
+
+  const includeDead = selector.includeDead ?? false
+  const baseCandidates = gatherCandidates(state, selector.side, userId, includeDead)
+
+  if (selector.mode === 'self') {
+    return includeDead || user.alive ? [userId] : []
+  }
+
+  let candidates = selector.condition
+    ? baseCandidates.filter((actor) => evaluateFilter(actor, selector.condition!))
+    : baseCandidates
+
+  if (!includeDead) {
+    candidates = candidates.filter((actor) => actor.alive)
+  }
+
+  if (candidates.length === 0) {
+    return []
+  }
+
+  switch (selector.mode) {
+    case 'single':
+      return [candidates[0].id]
+    case 'all':
+      return candidates.map((actor) => actor.id)
+    case 'random':
+      return pickRandom(state, candidates, normalizeCount('random', selector.count)).map(
+        (actor) => actor.id,
+      )
+    case 'lowest':
+    case 'highest': {
+      const sorted = sortByMetric(candidates, selector.ofWhat, selector.mode === 'lowest')
+      const limit = normalizeCount(selector.mode, selector.count)
+      return sorted.slice(0, limit || 1).map((actor) => actor.id)
+    }
+    case 'condition':
+      return candidates
+        .slice(0, selector.count != null ? Math.max(0, selector.count) : candidates.length)
+        .map((actor) => actor.id)
+    case 'self':
+    default:
+      return includeDead || user.alive ? [userId] : []
+  }
+}
+
+function gatherCandidates(
+  state: BattleState,
+  side: TargetSelector['side'],
+  userId: string,
+  includeDead: boolean,
+): Actor[] {
+  const user = state.actors[userId]
+  const sameSide = state.sidePlayer.includes(userId) ? state.sidePlayer : state.sideEnemy
+  const oppositeSide = sameSide === state.sidePlayer ? state.sideEnemy : state.sidePlayer
+
+  const fromIds = (ids: string[]): Actor[] =>
+    ids
+      .map((id) => state.actors[id])
+      .filter((actor): actor is Actor => Boolean(actor) && (includeDead || actor.alive))
+
+  switch (side) {
+    case 'self':
+      return includeDead || user?.alive ? [user].filter(Boolean) as Actor[] : []
+    case 'ally':
+      return fromIds(sameSide)
+    case 'enemy':
+      return fromIds(oppositeSide)
+    case 'any':
+      return [...fromIds(sameSide), ...fromIds(oppositeSide)]
+    default:
+      return []
+  }
+}
+
+function evaluateFilter(actor: Actor, filter: Filter): boolean {
+  let result = true
+
+  if (filter.test) {
+    result = result && evaluateTest(actor, filter.test)
+  }
+
+  if (filter.all) {
+    result = result && filter.all.every((inner) => evaluateFilter(actor, inner))
+  }
+
+  if (filter.any) {
+    result = result && filter.any.some((inner) => evaluateFilter(actor, inner))
+  }
+
+  if (filter.not) {
+    result = result && !evaluateFilter(actor, filter.not)
+  }
+
+  return result
+}
+
+function evaluateTest(
+  actor: Actor,
+  test: NonNullable<Filter['test']>,
+): boolean {
+  const { key, op, value } = test
+  switch (key) {
+    case 'hpPct':
+      return compareNumeric(fraction(actor.stats.hp, actor.stats.maxHp), op, value)
+    case 'staPct':
+      return compareNumeric(fraction(actor.stats.sta, actor.stats.maxSta), op, value)
+    case 'mpPct':
+      return compareNumeric(fraction(actor.stats.mp, actor.stats.maxMp), op, value)
+    case 'atk':
+      return compareNumeric(actor.stats.atk, op, value)
+    case 'def':
+      return compareNumeric(actor.stats.def, op, value)
+    case 'lv':
+      return compareNumeric(actor.stats.lv, op, value)
+    case 'hasStatus':
+      return compareSet(
+        actor.statuses.map((entry) => entry.id),
+        op,
+        value,
+      )
+    case 'tag':
+      return compareSet(actor.tags ?? [], op, value)
+    case 'clazz':
+      return compareValue(actor.clazz ?? null, op, value)
+    default:
+      return false
+  }
+}
+
+function compareNumeric(actual: number, op: ConditionOp, expected: unknown): boolean {
+  if (op === 'in' || op === 'notIn') {
+    const values = Array.isArray(expected) ? expected : [expected]
+    const numbers = values
+      .map((entry) => (typeof entry === 'number' ? entry : Number(entry)))
+      .filter((entry) => Number.isFinite(entry))
+    const has = numbers.some((entry) => entry === actual)
+    return op === 'in' ? has : !has
+  }
+
+  const expectedNumber = typeof expected === 'number' ? expected : Number(expected)
+  if (!Number.isFinite(expectedNumber)) {
+    return false
+  }
+
+  switch (op) {
+    case 'lt':
+      return actual < expectedNumber
+    case 'lte':
+      return actual <= expectedNumber
+    case 'eq':
+      return actual === expectedNumber
+    case 'gte':
+      return actual >= expectedNumber
+    case 'gt':
+      return actual > expectedNumber
+    case 'ne':
+      return actual !== expectedNumber
+    default:
+      return false
+  }
+}
+
+function compareValue(actual: unknown, op: ConditionOp, expected: unknown): boolean {
+  if (op === 'in' || op === 'notIn') {
+    const values = Array.isArray(expected) ? expected : [expected]
+    const has = values.some((entry) => entry === actual)
+    return op === 'in' ? has : !has
+  }
+
+  switch (op) {
+    case 'eq':
+      return actual === expected
+    case 'ne':
+      return actual !== expected
+    case 'lt':
+    case 'lte':
+    case 'gt':
+    case 'gte':
+      if (typeof actual === 'number' && typeof expected === 'number') {
+        return compareNumeric(actual, op, expected)
+      }
+      return false
+    default:
+      return false
+  }
+}
+
+function compareSet(actual: string[], op: ConditionOp, expected: unknown): boolean {
+  const values = Array.isArray(expected) ? expected : [expected]
+  const cleaned = values.filter((entry): entry is string => typeof entry === 'string')
+
+  switch (op) {
+    case 'eq':
+      return cleaned.every((entry) => actual.includes(entry))
+    case 'ne':
+      return cleaned.every((entry) => !actual.includes(entry))
+    case 'in':
+      return cleaned.some((entry) => actual.includes(entry))
+    case 'notIn':
+      return cleaned.every((entry) => !actual.includes(entry))
+    default:
+      return false
+  }
+}
+
+function normalizeCount(mode: TargetSelector['mode'], provided?: number): number {
+  if (provided != null) {
+    return Math.max(0, provided)
+  }
+  switch (mode) {
+    case 'single':
+      return 1
+    case 'random':
+      return 1
+    case 'lowest':
+    case 'highest':
+      return 1
+    default:
+      return 0
+  }
+}
+
+function fraction(current: number, max: number): number {
+  if (max <= 0) return 0
+  return current / max
+}
+
+function sortByMetric(actors: Actor[], key: CompareKey | undefined, asc: boolean): Actor[] {
+  const metricKey =
+    key && ['hpPct', 'staPct', 'mpPct', 'atk', 'def', 'lv'].includes(key) ? key : 'hpPct'
+  const scored = actors.map((actor) => ({ actor, value: getMetric(actor, metricKey as CompareKey) }))
+  scored.sort((a, b) => (asc ? a.value - b.value : b.value - a.value))
+  return scored.map((entry) => entry.actor)
+}
+
+function getMetric(actor: Actor, key: CompareKey): number {
+  switch (key) {
+    case 'hpPct':
+      return fraction(actor.stats.hp, actor.stats.maxHp)
+    case 'staPct':
+      return fraction(actor.stats.sta, actor.stats.maxSta)
+    case 'mpPct':
+      return fraction(actor.stats.mp, actor.stats.maxMp)
+    case 'atk':
+      return actor.stats.atk
+    case 'def':
+      return actor.stats.def
+    case 'lv':
+      return actor.stats.lv
+    default:
+      return fraction(actor.stats.hp, actor.stats.maxHp)
+  }
+}
+
+function pickRandom(state: BattleState, actors: Actor[], count: number): Actor[] {
+  if (count <= 0) return []
+  const pool = actors.slice()
+  const result: Actor[] = []
+  while (result.length < count && pool.length > 0) {
+    const index = Math.floor(nextRandom(state) * pool.length)
+    result.push(pool.splice(index, 1)[0])
+  }
+  return result
+}
+
+function nextRandom(state: BattleState): number {
+  const seed = state.rngSeed >>> 0
+  const next = (Math.imul(seed, RNG_A) + RNG_C) >>> 0
+  state.rngSeed = next
+  return next / RNG_M
 }

--- a/minmmo/src/engine/battle/types.ts
+++ b/minmmo/src/engine/battle/types.ts
@@ -3,6 +3,23 @@ export type Targeting = 'self' | 'single' | 'all' | 'random' | 'lowest' | 'highe
 export type Resource = 'hp' | 'sta' | 'mp'
 
 export interface Status { id: string; turns: number; stacks?: number }
+
+export interface ShieldState {
+  id: string
+  hp: number
+  element?: string
+}
+
+export interface TauntState {
+  sourceId: string
+  turns: number
+}
+
+export interface ChargeState {
+  remaining: number
+  max: number
+}
+
 export interface Stats  {
   maxHp:number; hp:number;
   maxSta:number; sta:number;
@@ -24,6 +41,10 @@ export interface BattleState {
   sidePlayer: string[]; sideEnemy: string[];
   inventory: InventoryEntry[];
   log: string[];
+  cooldowns: Record<string, Record<string, number>>;
+  charges: Record<string, Record<string, ChargeState>>;
+  shields: Record<string, Record<string, ShieldState>>;
+  taunts: Record<string, TauntState | undefined>;
   ended?: { reason: 'fled' | 'defeat' | 'victory' };
 }
 

--- a/minmmo/src/game/save.ts
+++ b/minmmo/src/game/save.ts
@@ -1,0 +1,215 @@
+import type { InventoryEntry, Stats } from '@engine/battle/types';
+
+export interface PlayerProfile {
+  name: string;
+  clazz: string;
+  level: number;
+  xp: number;
+  gold: number;
+  stats: Stats;
+  unlockedSkills: string[];
+  equippedSkills: string[];
+  inventory: InventoryEntry[];
+}
+
+export interface MerchantStockEntry {
+  id: string;
+  qty: number;
+  basePrice: number;
+}
+
+export interface MerchantState {
+  stock: MerchantStockEntry[];
+  restockIn: number;
+}
+
+export interface WorldState {
+  merchants: Record<string, MerchantState>;
+  flags: Record<string, boolean>;
+  turn: number;
+  lastLocation?: string;
+}
+
+export interface SaveData {
+  profile?: PlayerProfile;
+  world: WorldState;
+}
+
+const SAVE_KEY = 'minmmo:save';
+const storage: Storage | undefined = typeof localStorage === 'undefined' ? undefined : localStorage;
+
+function defaultWorld(): WorldState {
+  return { merchants: {}, flags: {}, turn: 0 };
+}
+
+function deepClone<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((entry) => deepClone(entry)) as unknown as T;
+  }
+  if (value && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      result[key] = deepClone(entry);
+    }
+    return result as T;
+  }
+  return value;
+}
+
+let cache: SaveData = { profile: undefined, world: defaultWorld() };
+
+(function init() {
+  if (!storage) {
+    return;
+  }
+  try {
+    const raw = storage.getItem(SAVE_KEY);
+    if (!raw) {
+      return;
+    }
+    const parsed = JSON.parse(raw);
+    cache = normalizeSave(parsed);
+  } catch {
+    cache = { profile: undefined, world: defaultWorld() };
+  }
+})();
+
+function normalizeSave(input: any): SaveData {
+  const world = input && typeof input.world === 'object' ? input.world : {};
+  return {
+    profile: input && typeof input.profile === 'object' ? sanitizeProfile(input.profile) : undefined,
+    world: sanitizeWorld(world),
+  };
+}
+
+function sanitizeProfile(input: any): PlayerProfile {
+  const stats = (input?.stats ?? {}) as Partial<Stats>;
+  const safeStats: Stats = {
+    maxHp: Number(stats.maxHp) || 1,
+    hp: Number(stats.hp) || Number(stats.maxHp) || 1,
+    maxSta: Number(stats.maxSta) || 0,
+    sta: Number(stats.sta) || Number(stats.maxSta) || 0,
+    maxMp: Number(stats.maxMp) || 0,
+    mp: Number(stats.mp) || Number(stats.maxMp) || 0,
+    atk: Number(stats.atk) || 1,
+    def: Number(stats.def) || 0,
+    lv: Number(stats.lv) || Number(input?.level) || 1,
+    xp: Number(stats.xp) || Number(input?.xp) || 0,
+    gold: Number(stats.gold) || Number(input?.gold) || 0,
+  };
+  return {
+    name: typeof input?.name === 'string' && input.name ? input.name : 'Adventurer',
+    clazz: typeof input?.clazz === 'string' && input.clazz ? input.clazz : 'Knight',
+    level: Number(input?.level) || safeStats.lv || 1,
+    xp: Number(input?.xp) || safeStats.xp || 0,
+    gold: Number(input?.gold) || safeStats.gold || 0,
+    stats: safeStats,
+    unlockedSkills: Array.isArray(input?.unlockedSkills)
+      ? Array.from(new Set(input.unlockedSkills.filter((id: unknown) => typeof id === 'string')))
+      : [],
+    equippedSkills: Array.isArray(input?.equippedSkills)
+      ? Array.from(new Set(input.equippedSkills.filter((id: unknown) => typeof id === 'string')))
+      : [],
+    inventory: Array.isArray(input?.inventory)
+      ? input.inventory
+          .map((entry: any) => ({ id: String(entry?.id ?? ''), qty: Number(entry?.qty) || 0 }))
+          .filter((entry: InventoryEntry) => entry.id && entry.qty > 0)
+      : [],
+  };
+}
+
+function sanitizeWorld(input: any): WorldState {
+  const merchants: Record<string, MerchantState> = {};
+  if (input && typeof input.merchants === 'object') {
+    for (const [id, state] of Object.entries(input.merchants as Record<string, any>)) {
+      if (!id) continue;
+      merchants[id] = {
+        stock: Array.isArray(state?.stock)
+          ? state.stock
+              .map((entry: any) => ({
+                id: String(entry?.id ?? ''),
+                qty: Number(entry?.qty) || 0,
+                basePrice: Number(entry?.basePrice) || 0,
+              }))
+              .filter((entry: MerchantStockEntry) => entry.id && entry.qty > 0)
+          : [],
+        restockIn: Math.max(0, Number(state?.restockIn) || 0),
+      };
+    }
+  }
+  return {
+    merchants,
+    flags: input && typeof input.flags === 'object' ? { ...input.flags } : {},
+    turn: Math.max(0, Number(input?.turn) || 0),
+    lastLocation: typeof input?.lastLocation === 'string' ? input.lastLocation : undefined,
+  };
+}
+
+function persist() {
+  if (!storage) return;
+  try {
+    storage.setItem(SAVE_KEY, JSON.stringify(cache));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+export function getSave(): SaveData {
+  return deepClone(cache);
+}
+
+export function getProfile(): PlayerProfile | undefined {
+  return cache.profile ? deepClone(cache.profile) : undefined;
+}
+
+export function setProfile(profile: PlayerProfile | undefined) {
+  cache.profile = profile ? deepClone(profile) : undefined;
+  persist();
+}
+
+export function getWorld(): WorldState {
+  if (!cache.world) {
+    cache.world = defaultWorld();
+  }
+  return deepClone(cache.world);
+}
+
+export function setWorld(world: WorldState) {
+  cache.world = deepClone(world);
+  persist();
+}
+
+export function saveAll(profile: PlayerProfile | undefined, world: WorldState) {
+  cache = {
+    profile: profile ? deepClone(profile) : undefined,
+    world: deepClone(world),
+  };
+  persist();
+}
+
+export function resetSave() {
+  cache = { profile: undefined, world: defaultWorld() };
+  persist();
+}
+
+export function mergeInventoryEntry(inventory: InventoryEntry[], entry: InventoryEntry) {
+  if (!entry.id || !Number.isFinite(entry.qty)) return;
+  const existing = inventory.find((item) => item.id === entry.id);
+  if (existing) {
+    existing.qty += entry.qty;
+  } else {
+    inventory.push({ id: entry.id, qty: entry.qty });
+  }
+  if (existing && existing.qty <= 0) {
+    const idx = inventory.indexOf(existing);
+    if (idx >= 0) inventory.splice(idx, 1);
+  }
+}
+
+export function clampInventory(inventory: InventoryEntry[]) {
+  for (let i = inventory.length - 1; i >= 0; i -= 1) {
+    if (inventory[i].qty <= 0) {
+      inventory.splice(i, 1);
+    }
+  }
+}

--- a/minmmo/src/game/scenes/Battle.ts
+++ b/minmmo/src/game/scenes/Battle.ts
@@ -1,50 +1,435 @@
+import Phaser from 'phaser';
+import { CONFIG } from '@config/store';
+import { Items, Skills, Enemies, Statuses } from '@content/registry';
+import type { RuntimeItem, RuntimeSkill } from '@content/adapters';
+import { createState } from '@engine/battle/state';
+import { useItem, useSkill, endTurn } from '@engine/battle/actions';
+import type { Actor, BattleState, InventoryEntry } from '@engine/battle/types';
+import {
+  PlayerProfile,
+  WorldState,
+  MerchantState,
+  saveAll,
+  clampInventory,
+} from '@game/save';
 
-import Phaser from 'phaser'
-import { createState } from '@engine/battle/state'
-import { useSkill, useItem, endTurn } from '@engine/battle/actions'
-import { Skills, Items } from '@content/registry'
+interface BattleInitData {
+  profile: PlayerProfile;
+  world: WorldState;
+  enemyId: string;
+  enemyLevel: number;
+}
 
-type BattleInit = { profile:any; stats:any; inventory:any[]; enemyKind:string; enemyLevel:number }
+interface TargetButton {
+  actorId: string;
+  text: Phaser.GameObjects.Text;
+}
+
+const PLAYER_ID = 'player';
+const BAR_WIDTH = 200;
+const BAR_HEIGHT = 12;
 
 export class Battle extends Phaser.Scene {
-  state: any
-  constructor(){ super('Battle') }
-  create(data: BattleInit){
-    const player = {
-      id: 'P1', name: data.profile.username ?? 'Hero', clazz: data.profile.clazz,
-      stats: { ...data.stats }, statuses: [], alive: true, tags: ['player']
+  private profile!: PlayerProfile;
+  private world!: WorldState;
+  private state!: BattleState;
+  private playerId = PLAYER_ID;
+  private barGraphics!: Phaser.GameObjects.Graphics;
+  private actorLabels: Record<string, Phaser.GameObjects.Text> = {};
+  private statusLabels: Record<string, Phaser.GameObjects.Text> = {};
+  private logText!: Phaser.GameObjects.Text;
+  private skillButtons: Phaser.GameObjects.Text[] = [];
+  private itemButtons: Phaser.GameObjects.Text[] = [];
+  private endTurnButton?: Phaser.GameObjects.Text;
+  private targetPrompt?: Phaser.GameObjects.Text;
+  private targetButtons: TargetButton[] = [];
+  private outcomeHandled = false;
+
+  constructor() {
+    super('Battle');
+  }
+
+  create(data: BattleInitData) {
+    this.profile = data.profile;
+    this.world = data.world;
+    const enemyFactory = Enemies()[data.enemyId];
+    if (!enemyFactory) {
+      this.scene.start('Overworld', { summary: [`Enemy ${data.enemyId} is not configured.`] });
+      return;
     }
-    const enemy = {
-      id: 'E1', name: data.enemyKind ?? 'Enemy', color: 0xff3333,
-      stats: { maxHp: 20, hp: 20, maxSta: 0, sta: 0, maxMp: 0, mp: 0, atk: 4, def: 2, lv: data.enemyLevel ?? 1, xp:0, gold:0 },
-      statuses: [], alive: true, tags: ['enemy']
-    }
+
+    const playerActor = this.createPlayerActor(this.profile);
+    const enemyActor = enemyFactory(Math.max(1, Math.floor(data.enemyLevel)));
 
     this.state = createState({
-      rngSeed: Math.floor(Math.random()*1e9),
-      actors: { [player.id]: player, [enemy.id]: enemy },
-      sidePlayer: [player.id], sideEnemy: [enemy.id],
-      inventory: data.inventory ?? [],
-    })
-    this.add.text(20,20,'Battle started. Click buttons.',{ color:'#e6e8ef' })
-    const logText = this.add.text(20,50,'', { color:'#8b8fa3' })
+      rngSeed: Math.floor(Math.random() * 1e9),
+      actors: { [playerActor.id]: playerActor, [enemyActor.id]: enemyActor },
+      sidePlayer: [playerActor.id],
+      sideEnemy: [enemyActor.id],
+      inventory: this.profile.inventory.map((entry) => ({ id: entry.id, qty: entry.qty })),
+    });
 
-    const skillBtn = this.add.text(20, 420, '[Use Skill]', { color:'#7c5cff' }).setInteractive()
-    skillBtn.on('pointerdown', ()=>{
-      const ids = Object.keys(Skills())
-      if (!ids.length) { this.state.log.push('No skills in config.'); render(); return }
-      useSkill(this.state, Skills()[ids[0]], 'P1', ['E1']); render()
-    })
-    const itemBtn = this.add.text(140, 420, '[Use Item]', { color:'#7c5cff' }).setInteractive()
-    itemBtn.on('pointerdown', ()=>{
-      const ids = Object.keys(Items())
-      if (!ids.length) { this.state.log.push('No items in config.'); render(); return }
-      useItem(this.state, Items()[ids[0]], 'P1', ['E1']); render()
-    })
-    const endBtn = this.add.text(260, 420, '[End Turn]', { color:'#7c5cff' }).setInteractive()
-    endBtn.on('pointerdown', ()=>{ endTurn(this.state); render() })
+    this.barGraphics = this.add.graphics();
+    this.logText = this.add.text(20, 260, '', { color: '#8b8fa3', wordWrap: { width: 760 } });
 
-    const render = ()=> { logText.setText(this.state.log.slice(-8).join('\n')) }
-    render()
+    this.buildStaticUi();
+    this.renderActions();
+    this.renderState();
+  }
+
+  private buildStaticUi() {
+    this.add.text(20, 20, 'Battle — defeat all enemies!', { color: '#e6e8ef', fontSize: '18px' });
+    const enemyCount = this.state.sideEnemy.length;
+    this.actorLabels = {};
+    this.statusLabels = {};
+    const playerText = this.add.text(20, 60, '', { color: '#e6e8ef' });
+    const playerStatus = this.add.text(20, 90, '', { color: '#7c5cff', wordWrap: { width: 360 } });
+    this.actorLabels[this.playerId] = playerText;
+    this.statusLabels[this.playerId] = playerStatus;
+
+    for (let i = 0; i < enemyCount; i += 1) {
+      const actorId = this.state.sideEnemy[i];
+      const baseY = 60 + i * 80;
+      this.actorLabels[actorId] = this.add.text(420, baseY, '', { color: '#f5c6a5' });
+      this.statusLabels[actorId] = this.add.text(420, baseY + 24, '', { color: '#7c5cff', wordWrap: { width: 340 } });
+    }
+
+    this.endTurnButton = this.add
+      .text(650, 420, '[End Turn]', { color: '#7c5cff' })
+      .setInteractive({ useHandCursor: true });
+    this.endTurnButton.on('pointerdown', () => {
+      if (this.state.ended) return;
+      endTurn(this.state);
+      this.afterAction();
+    });
+  }
+
+  private renderActions() {
+    for (const btn of this.skillButtons) btn.destroy();
+    for (const btn of this.itemButtons) btn.destroy();
+    this.skillButtons = [];
+    this.itemButtons = [];
+
+    let skillY = 320;
+    for (const id of this.profile.equippedSkills) {
+      const skill = Skills()[id];
+      if (!skill) continue;
+      const label = `[Skill] ${skill.name}`;
+      const text = this.add.text(20, skillY, label, { color: '#7c5cff' }).setInteractive({ useHandCursor: true });
+      text.on('pointerdown', () => {
+        if (this.state.ended) return;
+        this.handleSkill(skill);
+      });
+      this.skillButtons.push(text);
+      skillY += 24;
+    }
+
+    let itemY = 320;
+    for (const entry of this.state.inventory) {
+      const item = Items()[entry.id];
+      if (!item) continue;
+      const label = `[Item] ${item.name} x${entry.qty}`;
+      const text = this.add.text(220, itemY, label, { color: '#7c5cff' }).setInteractive({ useHandCursor: true });
+      text.on('pointerdown', () => {
+        if (this.state.ended) return;
+        this.handleItem(item);
+      });
+      this.itemButtons.push(text);
+      itemY += 24;
+    }
+  }
+
+  private handleSkill(skill: RuntimeSkill) {
+    this.clearTargetPicker();
+    const selector = skill.targeting;
+    if (this.needsManualTarget(selector)) {
+      const targets = this.collectTargets(selector, this.playerId);
+      this.promptForTarget(targets, (targetId) => {
+        useSkill(this.state, skill, this.playerId, [targetId]);
+        this.afterAction();
+      });
+    } else {
+      useSkill(this.state, skill, this.playerId);
+      this.afterAction();
+    }
+  }
+
+  private handleItem(item: RuntimeItem) {
+    this.clearTargetPicker();
+    const selector = item.targeting;
+    if (this.needsManualTarget(selector)) {
+      const targets = this.collectTargets(selector, this.playerId);
+      this.promptForTarget(targets, (targetId) => {
+        useItem(this.state, item, this.playerId, [targetId]);
+        this.afterAction();
+      });
+    } else {
+      useItem(this.state, item, this.playerId);
+      this.afterAction();
+    }
+  }
+
+  private needsManualTarget(selector: RuntimeSkill['targeting']): boolean {
+    return selector.mode === 'single' && selector.side !== 'self';
+  }
+
+  private collectTargets(selector: RuntimeSkill['targeting'], userId: string): string[] {
+    const allies = this.state.sidePlayer.includes(userId) ? this.state.sidePlayer : this.state.sideEnemy;
+    const enemies = this.state.sidePlayer.includes(userId) ? this.state.sideEnemy : this.state.sidePlayer;
+    let pool: string[] = [];
+    switch (selector.side) {
+      case 'self':
+        pool = [userId];
+        break;
+      case 'ally':
+        pool = allies.slice();
+        break;
+      case 'enemy':
+        pool = enemies.slice();
+        break;
+      case 'any':
+        pool = [...allies, ...enemies];
+        break;
+      default:
+        pool = enemies.slice();
+        break;
+    }
+    if (!selector.includeDead) {
+      pool = pool.filter((id) => this.state.actors[id]?.alive);
+    }
+    return pool;
+  }
+
+  private promptForTarget(candidates: string[], onPick: (targetId: string) => void) {
+    this.clearTargetPicker();
+    if (!candidates.length) {
+      onPick(this.playerId);
+      return;
+    }
+    this.targetPrompt = this.add.text(420, 300, 'Choose target:', { color: '#e6e8ef' });
+    let y = 330;
+    for (const id of candidates) {
+      const actor = this.state.actors[id];
+      if (!actor) continue;
+      const text = this.add
+        .text(420, y, `${actor.name} (${Math.max(0, actor.stats.hp)}/${actor.stats.maxHp})`, { color: '#7c5cff' })
+        .setInteractive({ useHandCursor: true });
+      text.on('pointerdown', () => {
+        this.clearTargetPicker();
+        onPick(id);
+      });
+      this.targetButtons.push({ actorId: id, text });
+      y += 22;
+    }
+    const cancel = this.add.text(420, y + 10, '[Cancel]', { color: '#8b8fa3' }).setInteractive({ useHandCursor: true });
+    cancel.on('pointerdown', () => {
+      this.clearTargetPicker();
+    });
+    this.targetButtons.push({ actorId: 'cancel', text: cancel });
+  }
+
+  private clearTargetPicker() {
+    if (this.targetPrompt) {
+      this.targetPrompt.destroy();
+      this.targetPrompt = undefined;
+    }
+    for (const entry of this.targetButtons) entry.text.destroy();
+    this.targetButtons = [];
+  }
+
+  private afterAction() {
+    clampInventory(this.state.inventory);
+    this.renderActions();
+    this.renderState();
+    this.checkOutcome();
+  }
+
+  private renderState() {
+    this.barGraphics.clear();
+    const player = this.state.actors[this.playerId];
+    if (player) {
+      this.updateActorPanel(player, 20, 120);
+    }
+    for (let i = 0; i < this.state.sideEnemy.length; i += 1) {
+      const enemyId = this.state.sideEnemy[i];
+      const actor = this.state.actors[enemyId];
+      if (actor) {
+        const baseY = 120 + i * 80;
+        this.updateActorPanel(actor, 420, baseY);
+      }
+    }
+    const recent = this.state.log.slice(-7);
+    this.logText.setText(recent.join('\n'));
+  }
+
+  private updateActorPanel(actor: Actor, x: number, baseY: number) {
+    const label = this.actorLabels[actor.id];
+    const statusLabel = this.statusLabels[actor.id];
+    const { stats } = actor;
+    if (label) {
+      label.setText(`${actor.name} — HP ${Math.max(0, Math.floor(stats.hp))}/${stats.maxHp}  STA ${stats.sta}/${stats.maxSta}  MP ${stats.mp}/${stats.maxMp}`);
+    }
+    if (statusLabel) {
+      const statuses = actor.statuses.length
+        ? actor.statuses
+            .map((s) => {
+              const template = Statuses()[s.id];
+              const icon = template?.icon ?? template?.name ?? s.id;
+              const stackStr = s.stacks && s.stacks > 1 ? ` x${s.stacks}` : '';
+              return `${icon ?? s.id} (${s.turns}${stackStr})`;
+            })
+            .join(', ')
+        : 'None';
+      statusLabel.setText(`Status: ${statuses}`);
+    }
+    this.drawBars(x, baseY, stats);
+  }
+
+  private drawBars(x: number, y: number, stats: Actor['stats']) {
+    this.drawBar(x, y, BAR_WIDTH, BAR_HEIGHT, stats.hp / Math.max(1, stats.maxHp), 0xff4f64, '#2b2f45');
+    this.drawBar(x, y + 14, BAR_WIDTH, BAR_HEIGHT, stats.sta / Math.max(1, stats.maxSta || 1), 0x3ab0ff, '#2b2f45');
+    this.drawBar(x, y + 28, BAR_WIDTH, BAR_HEIGHT, stats.mp / Math.max(1, stats.maxMp || 1), 0x7c5cff, '#2b2f45');
+  }
+
+  private drawBar(x: number, y: number, width: number, height: number, pct: number, color: number, background: string) {
+    this.barGraphics.fillStyle(Phaser.Display.Color.HexStringToColor(background).color, 1);
+    this.barGraphics.fillRect(x, y, width, height);
+    this.barGraphics.fillStyle(color, 1);
+    const clamped = Math.max(0, Math.min(1, pct));
+    this.barGraphics.fillRect(x, y, width * clamped, height);
+  }
+
+  private checkOutcome() {
+    if (!this.state.ended || this.outcomeHandled) return;
+    this.outcomeHandled = true;
+    const summary = this.processOutcome();
+    this.time.delayedCall(600, () => {
+      this.scene.start('Overworld', { summary });
+    });
+  }
+
+  private processOutcome(): string[] {
+    const summary: string[] = [];
+    const balance = CONFIG().balance;
+    const reason = this.state.ended?.reason;
+    this.world.turn = (this.world.turn ?? 0) + 1;
+    for (const merchant of Object.values(this.world.merchants as Record<string, MerchantState>)) {
+      if (merchant.restockIn > 0) {
+        merchant.restockIn = Math.max(0, merchant.restockIn - 1);
+      }
+    }
+
+    this.profile.inventory = this.state.inventory.map((entry) => ({ id: entry.id, qty: entry.qty }));
+    clampInventory(this.profile.inventory);
+
+    if (reason === 'victory') {
+      const rewards = this.calculateRewards(balance.XP_CURVE, balance.GOLD_DROP, balance.LOOT_ROLLS);
+      this.profile.xp += rewards.xp;
+      this.profile.stats.xp = this.profile.xp;
+      this.profile.gold += rewards.gold;
+      this.profile.stats.gold = this.profile.gold;
+      this.applyLoot(rewards.loot);
+      this.updateLevelFromXp(balance.XP_CURVE);
+      summary.push(`Victory! +${rewards.xp} XP, +${rewards.gold} gold.`);
+      if (rewards.loot.length) {
+        summary.push(`Loot: ${rewards.loot.map((l) => `${l.id} x${l.qty}`).join(', ')}`);
+      }
+    } else if (reason === 'defeat') {
+      const economy: any = balance.ECONOMY ?? {};
+      const penaltyPct = typeof economy.defeatPenaltyPct === 'number' ? Math.min(1, Math.max(0, economy.defeatPenaltyPct)) : 1;
+      const goldLoss = Math.round(this.profile.gold * penaltyPct);
+      this.profile.gold = Math.max(0, this.profile.gold - goldLoss);
+      this.profile.stats.gold = this.profile.gold;
+      summary.push(`Defeated. Lost ${goldLoss} gold.`);
+    } else if (reason === 'fled') {
+      summary.push('You fled the battle.');
+    }
+
+    this.profile.stats.hp = this.profile.stats.maxHp;
+    this.profile.stats.sta = this.profile.stats.maxSta;
+    this.profile.stats.mp = this.profile.stats.maxMp;
+
+    saveAll(this.profile, this.world);
+    return summary;
+  }
+
+  private calculateRewards(
+    curve: { base: number; growth: number },
+    goldDrop: { mean: number; variance: number },
+    lootRolls: number,
+  ) {
+    let xp = 0;
+    let gold = 0;
+    const loot: InventoryEntry[] = [];
+    const rolls = Math.max(1, Math.round(lootRolls || 1));
+    for (const id of this.state.sideEnemy) {
+      const enemy = this.state.actors[id];
+      if (!enemy) continue;
+      xp += Math.round(curve.base + curve.growth * enemy.stats.lv);
+      gold += Math.max(0, Math.round(goldDrop.mean + goldDrop.variance * enemy.stats.lv));
+      const drops = enemy.meta?.itemDrops;
+      if (drops) {
+        for (const drop of drops) {
+          if (!drop.id || !drop.qty) continue;
+          this.mergeInventoryEntries(loot, { id: drop.id, qty: drop.qty * rolls });
+        }
+      }
+    }
+    return { xp, gold, loot };
+  }
+
+  private applyLoot(loot: InventoryEntry[]) {
+    for (const entry of loot) {
+      this.mergeInventoryEntries(this.profile.inventory, entry);
+    }
+    clampInventory(this.profile.inventory);
+  }
+
+  private mergeInventoryEntries(inventory: InventoryEntry[], entry: InventoryEntry) {
+    if (!entry.id || !Number.isFinite(entry.qty)) return;
+    const existing = inventory.find((i) => i.id === entry.id);
+    if (existing) {
+      existing.qty += entry.qty;
+    } else {
+      inventory.push({ id: entry.id, qty: entry.qty });
+    }
+  }
+
+  private updateLevelFromXp(curve: { base: number; growth: number }) {
+    let level = 1;
+    let xpRemaining = Math.max(0, this.profile.xp);
+    const maxIterations = 200;
+    for (let i = 0; i < maxIterations; i += 1) {
+      const threshold = Math.max(1, Math.round(curve.base * Math.pow(curve.growth, level - 1)));
+      if (xpRemaining < threshold) break;
+      xpRemaining -= threshold;
+      level += 1;
+    }
+    this.profile.level = level;
+    this.profile.stats.lv = level;
+  }
+
+  private createPlayerActor(profile: PlayerProfile): Actor {
+    return {
+      id: this.playerId,
+      name: profile.name,
+      clazz: profile.clazz,
+      stats: {
+        maxHp: profile.stats.maxHp,
+        hp: profile.stats.maxHp,
+        maxSta: profile.stats.maxSta,
+        sta: profile.stats.maxSta,
+        maxMp: profile.stats.maxMp,
+        mp: profile.stats.maxMp,
+        atk: profile.stats.atk,
+        def: profile.stats.def,
+        lv: profile.level,
+        xp: profile.xp,
+        gold: profile.gold,
+      },
+      statuses: [],
+      alive: true,
+      tags: ['player'],
+    };
   }
 }

--- a/minmmo/src/game/scenes/Overworld.ts
+++ b/minmmo/src/game/scenes/Overworld.ts
@@ -1,15 +1,530 @@
+import Phaser from 'phaser';
+import { CONFIG } from '@config/store';
+import { Items, NPCs, Skills } from '@content/registry';
+import type { InventoryEntry } from '@engine/battle/types';
+import {
+  PlayerProfile,
+  WorldState,
+  MerchantState,
+  MerchantStockEntry,
+  getProfile,
+  setProfile,
+  getWorld,
+  setWorld,
+  resetSave,
+  clampInventory,
+} from '@game/save';
 
-import Phaser from 'phaser'
+interface BattleInitData {
+  profile: PlayerProfile;
+  world: WorldState;
+  enemyId: string;
+  enemyLevel: number;
+}
+
+interface ReturnData {
+  summary?: string[];
+}
+
+const TEXT_COLOR = '#e6e8ef';
+const ACCENT_COLOR = '#7c5cff';
+const WARNING_COLOR = '#f08c8c';
 
 export class Overworld extends Phaser.Scene {
-  constructor(){ super('Overworld') }
-  create(){
-    this.add.text(20,20,'Overworld — press SPACE to battle',{ color:'#e6e8ef' })
-    this.input.keyboard!.on('keydown-SPACE', ()=>{
-      const profile = { username: 'Hero', clazz: 'Knight', color: 0xffffff }
-      const stats = { maxHp:30, hp:30, maxSta:12, sta:12, maxMp:4, mp:4, atk:5, def:6, lv:1, xp:0, gold:0 }
-      const inventory:any[] = []
-      this.scene.start('Battle', { profile, stats, inventory, enemyKind: 'Slime', enemyLevel: 1 })
-    })
+  private profile?: PlayerProfile;
+  private world: WorldState;
+  private ui: Phaser.GameObjects.GameObject[] = [];
+  private summaryLines: string[] = [];
+
+  constructor() {
+    super('Overworld');
+    this.world = getWorld();
+  }
+
+  create(data?: ReturnData) {
+    this.profile = getProfile();
+    this.world = getWorld();
+    this.summaryLines = data?.summary ?? [];
+    this.render();
+  }
+
+  private clearUi() {
+    for (const obj of this.ui) obj.destroy();
+    this.ui = [];
+  }
+
+  private render() {
+    this.clearUi();
+    const config = CONFIG();
+    let y = 20;
+    this.ui.push(this.add.text(20, y, 'MinMMO — Overworld', { color: TEXT_COLOR, fontSize: '20px' }));
+    y += 28;
+
+    if (this.summaryLines.length) {
+      this.ui.push(
+        this.add
+          .text(20, y, this.summaryLines.join('\n'), { color: ACCENT_COLOR, wordWrap: { width: 760 } })
+          .setDepth(1),
+      );
+      y += 20 * this.summaryLines.length + 10;
+    }
+
+    if (!this.profile) {
+      this.renderClassSelection(y, config);
+      return;
+    }
+
+    y = this.renderProfilePanel(y, config);
+    this.renderActions(y);
+  }
+
+  private renderClassSelection(startY: number, config = CONFIG()) {
+    let y = startY;
+    this.ui.push(this.add.text(20, y, 'Choose your class to begin:', { color: TEXT_COLOR }));
+    y += 24;
+    const classes = Object.entries(config.classes);
+    if (!classes.length) {
+      this.ui.push(this.add.text(20, y, 'No classes configured. Add one in the Admin.', { color: WARNING_COLOR }));
+      return;
+    }
+    for (const [clazz, preset] of classes) {
+      const desc = `${clazz} — HP ${preset.maxHp} / STA ${preset.maxSta} / MP ${preset.maxMp}`;
+      const txt = this.add
+        .text(20, y, `[${clazz}] ${desc}`, { color: ACCENT_COLOR })
+        .setInteractive({ useHandCursor: true });
+      txt.on('pointerdown', () => {
+        this.createProfileForClass(clazz);
+      });
+      this.ui.push(txt);
+      y += 22;
+    }
+    const reset = this.add
+      .text(20, y + 10, '[Reset Save]', { color: WARNING_COLOR })
+      .setInteractive({ useHandCursor: true });
+    reset.on('pointerdown', () => {
+      resetSave();
+      this.profile = undefined;
+      this.world = getWorld();
+      this.summaryLines = ['Save reset.'];
+      this.render();
+    });
+    this.ui.push(reset);
+  }
+
+  private renderProfilePanel(startY: number, config = CONFIG()) {
+    let y = startY;
+    const profile = this.profile!;
+    const slots = this.getMaxSkillSlots(profile.level, config.balance.SKILL_SLOTS_BY_LEVEL);
+    const infoLines = [
+      `${profile.name} the ${profile.clazz} — Lv ${profile.level}`,
+      `XP: ${profile.xp.toFixed(0)}  Gold: ${profile.gold.toFixed(0)}`,
+      `Stats: HP ${profile.stats.maxHp}  STA ${profile.stats.maxSta}  MP ${profile.stats.maxMp}  ATK ${profile.stats.atk}  DEF ${profile.stats.def}`,
+      `Equipped Skills (${profile.equippedSkills.length}/${slots}): ${profile.equippedSkills.join(', ') || 'None'}`,
+    ];
+    for (const line of infoLines) {
+      this.ui.push(this.add.text(20, y, line, { color: TEXT_COLOR }));
+      y += 20;
+    }
+
+    this.ui.push(this.add.text(20, y, 'Inventory:', { color: TEXT_COLOR }));
+    y += 20;
+    if (!profile.inventory.length) {
+      this.ui.push(this.add.text(32, y, '(Empty)', { color: '#8b8fa3' }));
+      y += 20;
+    } else {
+      for (const entry of profile.inventory) {
+        const item = Items()[entry.id];
+        const name = item?.name ?? entry.id;
+        this.ui.push(this.add.text(32, y, `${name} x${entry.qty}`, { color: '#8b8fa3' }));
+        y += 18;
+      }
+    }
+
+    this.ui.push(this.add.text(20, y, 'Unlocked Skills:', { color: TEXT_COLOR }));
+    y += 20;
+    if (!profile.unlockedSkills.length) {
+      this.ui.push(this.add.text(32, y, '(None)', { color: '#8b8fa3' }));
+      y += 20;
+    } else {
+      for (const id of profile.unlockedSkills) {
+        const skill = Skills()[id];
+        const equipped = profile.equippedSkills.includes(id);
+        const label = `${equipped ? '•' : '○'} ${skill?.name ?? id}`;
+        const txt = this.add
+          .text(32, y, label, { color: equipped ? ACCENT_COLOR : '#8b8fa3' })
+          .setInteractive({ useHandCursor: true });
+        txt.on('pointerdown', () => {
+          this.toggleSkillEquip(id, slots);
+        });
+        this.ui.push(txt);
+        y += 18;
+      }
+    }
+    y += 10;
+    return y;
+  }
+
+  private renderActions(startY: number) {
+    let y = startY;
+    const button = (label: string, color: string, handler: () => void) => {
+      const txt = this.add.text(20, y, label, { color }).setInteractive({ useHandCursor: true });
+      txt.on('pointerdown', handler);
+      this.ui.push(txt);
+      y += 24;
+    };
+
+    button('[Start Battle]', ACCENT_COLOR, () => this.showEncounterMenu());
+
+    const merchants = Object.values(NPCs()).filter((npc) => npc.kind === 'merchant');
+    for (const merchant of merchants) {
+      button(`[Visit ${merchant.name}]`, ACCENT_COLOR, () => this.openMerchant(merchant.id));
+    }
+
+    const trainers = Object.values(NPCs()).filter((npc) => npc.kind === 'trainer');
+    for (const trainer of trainers) {
+      button(`[Train with ${trainer.name}]`, ACCENT_COLOR, () => this.openTrainer(trainer.id));
+    }
+
+    button('[Reset Save]', WARNING_COLOR, () => {
+      resetSave();
+      this.profile = undefined;
+      this.world = getWorld();
+      this.summaryLines = ['Save reset.'];
+      this.render();
+    });
+  }
+
+  private toggleSkillEquip(skillId: string, slots: number) {
+    const profile = this.profile!;
+    const idx = profile.equippedSkills.indexOf(skillId);
+    if (idx >= 0) {
+      profile.equippedSkills.splice(idx, 1);
+    } else {
+      if (profile.equippedSkills.length >= slots) {
+        this.summaryLines = [`No free skill slots (max ${slots}).`];
+        this.render();
+        return;
+      }
+      profile.equippedSkills.push(skillId);
+    }
+    setProfile(profile);
+    this.summaryLines = [];
+    this.render();
+  }
+
+  private createProfileForClass(clazz: string) {
+    const config = CONFIG();
+    const preset = config.classes[clazz];
+    if (!preset) {
+      this.summaryLines = [`Class ${clazz} is not configured.`];
+      this.render();
+      return;
+    }
+    const skillIds = config.classSkills[clazz] ? [...config.classSkills[clazz]] : [];
+    const slots = this.getMaxSkillSlots(1, config.balance.SKILL_SLOTS_BY_LEVEL);
+    const equipped = skillIds.slice(0, slots);
+    const startItems = config.startItems[clazz] ? [...config.startItems[clazz]] : [];
+    const profile: PlayerProfile = {
+      name: 'Adventurer',
+      clazz,
+      level: 1,
+      xp: 0,
+      gold: 0,
+      stats: {
+        maxHp: preset.maxHp,
+        hp: preset.maxHp,
+        maxSta: preset.maxSta,
+        sta: preset.maxSta,
+        maxMp: preset.maxMp,
+        mp: preset.maxMp,
+        atk: preset.atk,
+        def: preset.def,
+        lv: 1,
+        xp: 0,
+        gold: 0,
+      },
+      unlockedSkills: skillIds,
+      equippedSkills: equipped,
+      inventory: startItems.map((entry) => ({ id: entry.id, qty: entry.qty ?? 1 })),
+    };
+    clampInventory(profile.inventory);
+    setProfile(profile);
+    this.profile = profile;
+    this.summaryLines = [`Welcome, ${profile.clazz}!`];
+    this.render();
+  }
+
+  private getMaxSkillSlots(level: number, slots: number[]): number {
+    const lvl = Math.max(1, level || 1);
+    if (!slots.length) return 0;
+    const index = Math.min(slots.length - 1, Math.max(0, lvl - 1));
+    return slots[index] ?? 0;
+  }
+
+  private showEncounterMenu() {
+    const profile = this.profile;
+    if (!profile) return;
+    const config = CONFIG();
+    const enemyEntries = Object.entries(config.enemies);
+    if (!enemyEntries.length) {
+      this.summaryLines = ['No enemies configured.'];
+      this.render();
+      return;
+    }
+    this.clearUi();
+    let y = 20;
+    this.ui.push(this.add.text(20, y, 'Choose an enemy:', { color: TEXT_COLOR }));
+    y += 26;
+    let selectedEnemy: string | null = null;
+    let level = Math.max(1, profile.level);
+    const levelText = this.add.text(20, 400, `Level: ${level}`, { color: TEXT_COLOR }).setInteractive({ useHandCursor: true });
+    levelText.on('pointerdown', () => {
+      level = Math.max(1, Math.min(99, level + 1));
+      levelText.setText(`Level: ${level}`);
+    });
+    this.ui.push(levelText);
+
+    const confirm = this.add
+      .text(200, 400, '[Start!]', { color: '#555b7a' })
+      .setInteractive({ useHandCursor: true });
+    confirm.on('pointerdown', () => {
+      if (!selectedEnemy) return;
+      this.launchBattle(selectedEnemy, level);
+    });
+    this.ui.push(confirm);
+
+    for (const [id, def] of enemyEntries) {
+      const txt = this.add
+        .text(20, y, `${def.name ?? id}`, { color: ACCENT_COLOR })
+        .setInteractive({ useHandCursor: true });
+      txt.on('pointerdown', () => {
+        selectedEnemy = id;
+        confirm.setColor(ACCENT_COLOR);
+      });
+      this.ui.push(txt);
+      y += 22;
+    }
+
+    const back = this.add.text(20, 440, '[Back]', { color: TEXT_COLOR }).setInteractive({ useHandCursor: true });
+    back.on('pointerdown', () => this.render());
+    this.ui.push(back);
+  }
+
+  private launchBattle(enemyId: string, level: number) {
+    const profile = this.profile;
+    if (!profile) return;
+    const battleData: BattleInitData = {
+      profile,
+      world: this.world,
+      enemyId,
+      enemyLevel: Math.max(1, Math.floor(level)),
+    };
+    this.scene.start('Battle', battleData);
+  }
+
+  private ensureMerchantState(npcId: string): MerchantState {
+    const economy = CONFIG().balance.ECONOMY;
+    if (!this.world.merchants[npcId]) {
+      this.world.merchants[npcId] = { stock: [], restockIn: 0 };
+    }
+    const state = this.world.merchants[npcId];
+    if (state.restockIn <= 0) {
+      const npc = NPCs()[npcId];
+      const stock: MerchantStockEntry[] = [];
+      if (npc?.inventory) {
+        for (const entry of npc.inventory) {
+          const qty = Number(entry.qty) || 1;
+          if (!entry.id || qty <= 0) continue;
+          const basePrice = this.resolveBasePrice(entry.price, entry.rarity);
+          stock.push({ id: entry.id, qty, basePrice });
+        }
+      }
+      state.stock = stock;
+      state.restockIn = Math.max(1, Math.floor(economy.restockTurns || 1));
+      setWorld(this.world);
+    }
+    return state;
+  }
+
+  private resolveBasePrice(price: number | undefined, rarity?: string) {
+    const economy = CONFIG().balance.ECONOMY;
+    if (typeof price === 'number' && Number.isFinite(price)) {
+      return Math.max(0, price);
+    }
+    const table = economy.priceByRarity ?? {};
+    if (rarity && typeof table[rarity as keyof typeof table] === 'number') {
+      return Math.max(0, table[rarity as keyof typeof table] || 0);
+    }
+    return Math.max(0, table.common || 0);
+  }
+
+  private openMerchant(npcId: string) {
+    const profile = this.profile;
+    if (!profile) return;
+    const economy = CONFIG().balance.ECONOMY;
+    const merchant = NPCs()[npcId];
+    const state = this.ensureMerchantState(npcId);
+    this.clearUi();
+    let y = 20;
+    this.ui.push(this.add.text(20, y, `${merchant?.name ?? 'Merchant'} — Shop`, { color: TEXT_COLOR }));
+    y += 26;
+    this.ui.push(this.add.text(20, y, `Gold: ${profile.gold.toFixed(0)}`, { color: ACCENT_COLOR }));
+    y += 24;
+    this.ui.push(this.add.text(20, y, 'Stock:', { color: TEXT_COLOR }));
+    y += 22;
+    if (!state.stock.length) {
+      this.ui.push(this.add.text(32, y, 'Sold out. Come back later.', { color: '#8b8fa3' }));
+      y += 22;
+    } else {
+      for (const entry of state.stock) {
+        const item = Items()[entry.id];
+        const name = item?.name ?? entry.id;
+        const price = Math.max(1, Math.round(entry.basePrice * (economy.buyMult || 1)));
+        const txt = this.add
+          .text(32, y, `${name} x${entry.qty} — ${price} gold`, { color: ACCENT_COLOR })
+          .setInteractive({ useHandCursor: true });
+        txt.on('pointerdown', () => {
+          if (entry.qty <= 0) return;
+          if (profile.gold < price) {
+            this.summaryLines = [`Not enough gold for ${name}.`];
+            this.render();
+            return;
+          }
+          entry.qty -= 1;
+          profile.gold -= price;
+          profile.stats.gold = profile.gold;
+          this.mergeInventory(profile.inventory, { id: entry.id, qty: 1 });
+          clampInventory(profile.inventory);
+          if (entry.qty <= 0) {
+            const idx = state.stock.indexOf(entry);
+            if (idx >= 0) state.stock.splice(idx, 1);
+          }
+          setProfile(profile);
+          setWorld(this.world);
+          this.openMerchant(npcId);
+        });
+        this.ui.push(txt);
+        y += 20;
+      }
+    }
+
+    y += 10;
+    this.ui.push(this.add.text(20, y, 'Sell:', { color: TEXT_COLOR }));
+    y += 22;
+    if (!profile.inventory.length) {
+      this.ui.push(this.add.text(32, y, 'Nothing to sell.', { color: '#8b8fa3' }));
+      y += 22;
+    } else {
+      for (const entry of profile.inventory) {
+        const item = Items()[entry.id];
+        const name = item?.name ?? entry.id;
+        const basePrice = this.resolveBasePrice(
+          merchant?.inventory?.find((i) => i.id === entry.id)?.price,
+          merchant?.inventory?.find((i) => i.id === entry.id)?.rarity,
+        );
+        const price = Math.max(1, Math.round(basePrice * (economy.sellMult || 0.5)));
+        const txt = this.add
+          .text(32, y, `${name} x${entry.qty} — sell ${price} gold`, { color: '#8b8fa3' })
+          .setInteractive({ useHandCursor: true });
+        txt.on('pointerdown', () => {
+          if (entry.qty <= 0) return;
+          entry.qty -= 1;
+          profile.gold += price;
+          profile.stats.gold = profile.gold;
+          if (entry.qty <= 0) {
+            const idx = profile.inventory.indexOf(entry);
+            if (idx >= 0) profile.inventory.splice(idx, 1);
+          }
+          this.addMerchantStock(state.stock, entry.id, 1, basePrice);
+          setProfile(profile);
+          setWorld(this.world);
+          this.openMerchant(npcId);
+        });
+        this.ui.push(txt);
+        y += 20;
+      }
+    }
+
+    const back = this.add.text(20, 440, '[Back]', { color: TEXT_COLOR }).setInteractive({ useHandCursor: true });
+    back.on('pointerdown', () => this.render());
+    this.ui.push(back);
+  }
+
+  private openTrainer(npcId: string) {
+    const profile = this.profile;
+    if (!profile) return;
+    const trainer = NPCs()[npcId];
+    const economy = CONFIG().balance.ECONOMY;
+    if (trainer?.trainer?.clazz && trainer.trainer.clazz !== profile.clazz) {
+      this.summaryLines = [`${trainer.name} only trains ${trainer.trainer.clazz}.`];
+      this.render();
+      return;
+    }
+    this.clearUi();
+    let y = 20;
+    this.ui.push(this.add.text(20, y, `${trainer?.name ?? 'Trainer'} — Skills`, { color: TEXT_COLOR }));
+    y += 26;
+    const teaches = trainer?.trainer?.teaches ?? [];
+    if (!teaches.length) {
+      this.ui.push(this.add.text(20, y, 'No skills available.', { color: '#8b8fa3' }));
+      y += 22;
+    } else {
+      for (const skillId of teaches) {
+        const skill = Skills()[skillId];
+        const base = trainer?.trainer?.priceBySkill?.[skillId];
+        const basePrice = this.resolveBasePrice(base, 'rare');
+        const price = Math.max(1, Math.round(basePrice * (economy.buyMult || 1)));
+        const owned = profile.unlockedSkills.includes(skillId);
+        const label = `${skill?.name ?? skillId} — ${owned ? 'Learned' : price + ' gold'}`;
+        const txt = this.add
+          .text(20, y, label, { color: owned ? '#8b8fa3' : ACCENT_COLOR })
+          .setInteractive({ useHandCursor: true });
+        txt.on('pointerdown', () => {
+          if (owned) return;
+          if (profile.gold < price) {
+            this.summaryLines = [`Not enough gold to learn ${skill?.name ?? skillId}.`];
+            this.render();
+            return;
+          }
+          profile.gold -= price;
+          profile.stats.gold = profile.gold;
+          profile.unlockedSkills.push(skillId);
+          setProfile(profile);
+          this.openTrainer(npcId);
+        });
+        this.ui.push(txt);
+        y += 22;
+      }
+    }
+
+    const back = this.add.text(20, 440, '[Back]', { color: TEXT_COLOR }).setInteractive({ useHandCursor: true });
+    back.on('pointerdown', () => this.render());
+    this.ui.push(back);
+  }
+
+  private mergeInventory(inventory: InventoryEntry[], entry: InventoryEntry) {
+    if (!entry.id || !Number.isFinite(entry.qty)) return;
+    const existing = inventory.find((item) => item.id === entry.id);
+    if (existing) {
+      existing.qty += entry.qty;
+    } else {
+      inventory.push({ id: entry.id, qty: entry.qty });
+    }
+  }
+
+  private addMerchantStock(stock: MerchantStockEntry[], id: string, qty: number, basePrice: number) {
+    if (!id || qty <= 0) return;
+    const existing = stock.find((entry) => entry.id === id);
+    if (existing) {
+      existing.qty += qty;
+      existing.basePrice = basePrice;
+    } else {
+      stock.push({ id, qty, basePrice });
+    }
+    for (let i = stock.length - 1; i >= 0; i -= 1) {
+      if (stock[i].qty <= 0) {
+        stock.splice(i, 1);
+      }
+    }
   }
 }

--- a/minmmo/tests/actions.basic.test.ts
+++ b/minmmo/tests/actions.basic.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RuntimeEffect, RuntimeItem, RuntimeSkill, RuntimeTargetSelector } from '@content/adapters'
+import { useItem, useSkill, endTurn } from '@engine/battle/actions'
+import { createState } from '@engine/battle/state'
+import type { Actor, BattleState } from '@engine/battle/types'
+import { DEFAULTS } from '@config/defaults'
+import * as configStore from '@config/store'
+
+function makeActor(id: string, overrides: Partial<Actor['stats']> = {}): Actor {
+  return {
+    id,
+    name: id,
+    stats: {
+      maxHp: 100,
+      hp: 100,
+      maxSta: 20,
+      sta: 20,
+      maxMp: 15,
+      mp: 15,
+      atk: 10,
+      def: 5,
+      lv: 1,
+      xp: 0,
+      gold: 0,
+      ...overrides,
+    },
+    statuses: [],
+    alive: true,
+    tags: id.startsWith('P') ? ['player'] : ['enemy'],
+  }
+}
+
+function makeSelector(selector: Partial<RuntimeTargetSelector>): RuntimeTargetSelector {
+  return {
+    side: 'enemy',
+    mode: 'single',
+    includeDead: false,
+    ...selector,
+  }
+}
+
+function flatEffect(kind: RuntimeEffect['kind'], amount: number): RuntimeEffect {
+  return {
+    kind,
+    value: {
+      kind: 'flat',
+      resolve: () => amount,
+      rawAmount: amount,
+    },
+    canCrit: false,
+    canMiss: false,
+  }
+}
+
+function percentEffect(kind: RuntimeEffect['kind'], fraction: number): RuntimeEffect {
+  return {
+    kind,
+    value: {
+      kind: 'percent',
+      resolve: () => fraction,
+      rawPercent: fraction * 100,
+    },
+    canCrit: false,
+    canMiss: false,
+  }
+}
+
+function makeSkill(partial: Partial<RuntimeSkill>): RuntimeSkill {
+  return {
+    id: 'test-skill',
+    type: 'skill',
+    name: 'Test Skill',
+    targeting: makeSelector({ side: 'enemy' }),
+    effects: [],
+    costs: { sta: 0, mp: 0, cooldown: 0 },
+    aiWeight: 1,
+    ...partial,
+  }
+}
+
+function makeItem(partial: Partial<RuntimeItem>): RuntimeItem {
+  return {
+    id: 'test-item',
+    type: 'item',
+    name: 'Test Item',
+    targeting: makeSelector({ side: 'enemy' }),
+    effects: [],
+    costs: { sta: 0, mp: 0, cooldown: 0 },
+    consumable: true,
+    aiWeight: 1,
+    ...partial,
+  }
+}
+
+function makeState(player: Actor, enemy: Actor): BattleState {
+  return createState({
+    rngSeed: 123,
+    actors: { [player.id]: player, [enemy.id]: enemy },
+    sidePlayer: [player.id],
+    sideEnemy: [enemy.id],
+    inventory: [],
+  })
+}
+
+let configSpy: ReturnType<typeof vi.spyOn> | undefined
+
+beforeEach(() => {
+  const cfg = JSON.parse(JSON.stringify(DEFAULTS))
+  cfg.balance.BASE_HIT = 1
+  cfg.balance.BASE_CRIT = 0
+  cfg.balance.DODGE_FLOOR = 0
+  cfg.balance.HIT_CEIL = 1
+  cfg.balance.ELEMENT_MATRIX = { neutral: { neutral: 1 } }
+  cfg.balance.RESISTS_BY_TAG = {}
+  configSpy = vi.spyOn(configStore, 'CONFIG').mockReturnValue(cfg)
+})
+
+afterEach(() => {
+  configSpy?.mockRestore()
+  vi.restoreAllMocks()
+})
+
+describe('battle actions basics', () => {
+  it('uses a damaging item to defeat an enemy', () => {
+    const player = makeActor('P1')
+    const enemy = makeActor('E1', { hp: 20, maxHp: 20 })
+    const state = makeState(player, enemy)
+
+    const bomb = makeItem({
+      name: 'Bomb',
+      effects: [flatEffect('damage', 50)],
+      targeting: makeSelector({ side: 'enemy' }),
+    })
+
+    state.inventory.push({ id: bomb.id, qty: 1 })
+
+    const result = useItem(state, bomb, player.id, [enemy.id])
+    expect(result.ok).toBe(true)
+    expect(state.actors[enemy.id]?.stats.hp).toBe(0)
+    expect(state.actors[enemy.id]?.alive).toBe(false)
+    expect(state.ended?.reason).toBe('victory')
+    expect(state.log[state.log.length - 1]).toContain('Victory')
+  })
+
+  it('heals allies by percent of max HP without exceeding cap', () => {
+    const player = makeActor('P1', { hp: 50, maxHp: 100 })
+    const enemy = makeActor('E1')
+    const state = makeState(player, enemy)
+
+    const mend = makeSkill({
+      name: 'Mend',
+      targeting: makeSelector({ side: 'ally', mode: 'single' }),
+      effects: [percentEffect('heal', 0.25)],
+    })
+
+    const result = useSkill(state, mend, player.id, [player.id])
+    expect(result.ok).toBe(true)
+    expect(state.actors[player.id]?.stats.hp).toBe(75)
+    expect(state.log.find((line) => line.includes('healed'))).toBeTruthy()
+  })
+
+  it('restores stamina with resource effects', () => {
+    const player = makeActor('P1', { sta: 2, maxSta: 10 })
+    const enemy = makeActor('E1')
+    const state = makeState(player, enemy)
+
+    const secondWind = makeSkill({
+      name: 'Second Wind',
+      targeting: makeSelector({ side: 'self', mode: 'self' }),
+      effects: [percentEffect('resource', 0.5)],
+    })
+    // attach resource info to effect
+    secondWind.effects[0].resource = 'sta'
+
+    const result = useSkill(state, secondWind, player.id, [player.id])
+    expect(result.ok).toBe(true)
+    expect(state.actors[player.id]?.stats.sta).toBe(7)
+  })
+
+  it('blocks actions when MP is insufficient', () => {
+    const player = makeActor('P1', { mp: 2 })
+    const enemy = makeActor('E1')
+    const state = makeState(player, enemy)
+
+    const expensive = makeSkill({
+      name: 'Arcane Burst',
+      costs: { sta: 0, mp: 5, cooldown: 0 },
+      effects: [flatEffect('damage', 10)],
+    })
+
+    const result = useSkill(state, expensive, player.id, [enemy.id])
+    expect(result.ok).toBe(false)
+    expect(state.actors[player.id]?.stats.mp).toBe(2)
+    expect(state.log[state.log.length - 1]).toContain('Not enough MP')
+  })
+
+  it('advances the turn order when ending a turn', () => {
+    const player = makeActor('P1')
+    const enemy = makeActor('E1')
+    const state = makeState(player, enemy)
+
+    expect(state.current).toBe(0)
+    expect(state.turn).toBe(1)
+
+    endTurn(state)
+    expect(state.current).toBe(1)
+    expect(state.turn).toBe(1)
+
+    endTurn(state)
+    expect(state.current).toBe(0)
+    expect(state.turn).toBe(2)
+    expect(state.log.filter((line) => line.includes('Turn')).length).toBeGreaterThan(0)
+  })
+})

--- a/minmmo/tests/actions.full.test.ts
+++ b/minmmo/tests/actions.full.test.ts
@@ -1,0 +1,382 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RuntimeEffect, RuntimeItem, RuntimeSkill, RuntimeTargetSelector } from '@content/adapters'
+import { applyStatus } from '@engine/battle/status'
+import { useItem, useSkill, endTurn } from '@engine/battle/actions'
+import { createState } from '@engine/battle/state'
+import type { Actor, BattleState } from '@engine/battle/types'
+import { DEFAULTS } from '@config/defaults'
+import * as configStore from '@config/store'
+import * as registry from '@content/registry'
+
+function makeActor(id: string, overrides: Partial<Actor['stats']> = {}): Actor {
+  return {
+    id,
+    name: id,
+    stats: {
+      maxHp: 100,
+      hp: 100,
+      maxSta: 20,
+      sta: 20,
+      maxMp: 15,
+      mp: 15,
+      atk: 10,
+      def: 5,
+      lv: 1,
+      xp: 0,
+      gold: 0,
+      ...overrides,
+    },
+    statuses: [],
+    alive: true,
+    tags: id.startsWith('P') ? ['player'] : ['enemy'],
+  }
+}
+
+function makeSelector(selector: Partial<RuntimeTargetSelector>): RuntimeTargetSelector {
+  return {
+    side: 'enemy',
+    mode: 'single',
+    includeDead: false,
+    ...selector,
+  }
+}
+
+function flatEffect(kind: RuntimeEffect['kind'], amount: number): RuntimeEffect {
+  return {
+    kind,
+    value: {
+      kind: 'flat',
+      resolve: () => amount,
+      rawAmount: amount,
+    },
+    canCrit: false,
+    canMiss: false,
+  }
+}
+
+function makeSkill(partial: Partial<RuntimeSkill>): RuntimeSkill {
+  return {
+    id: 'test-skill',
+    type: 'skill',
+    name: 'Test Skill',
+    targeting: makeSelector({ side: 'enemy' }),
+    effects: [],
+    costs: { sta: 0, mp: 0, cooldown: 0 },
+    aiWeight: 1,
+    ...partial,
+  }
+}
+
+function makeItem(partial: Partial<RuntimeItem>): RuntimeItem {
+  return {
+    id: 'test-item',
+    type: 'item',
+    name: 'Test Item',
+    targeting: makeSelector({ side: 'enemy' }),
+    effects: [],
+    costs: { sta: 0, mp: 0, cooldown: 0 },
+    consumable: true,
+    aiWeight: 1,
+    ...partial,
+  }
+}
+
+function makeState(players: Actor[], enemies: Actor[], inventory: { id: string; qty: number }[] = []): BattleState {
+  const actors: Record<string, Actor> = {}
+  const sidePlayer: string[] = []
+  const sideEnemy: string[] = []
+  for (const actor of players) {
+    actors[actor.id] = actor
+    sidePlayer.push(actor.id)
+  }
+  for (const actor of enemies) {
+    actors[actor.id] = actor
+    sideEnemy.push(actor.id)
+  }
+  return createState({
+    rngSeed: 123,
+    actors,
+    sidePlayer,
+    sideEnemy,
+    inventory,
+  })
+}
+
+let configSpy: ReturnType<typeof vi.spyOn> | undefined
+let statusesSpy: ReturnType<typeof vi.spyOn> | undefined
+
+beforeEach(() => {
+  const cfg = JSON.parse(JSON.stringify(DEFAULTS))
+  cfg.balance.BASE_HIT = 1
+  cfg.balance.BASE_CRIT = 0
+  cfg.balance.DODGE_FLOOR = 0
+  cfg.balance.HIT_CEIL = 1
+  cfg.balance.ELEMENT_MATRIX = { neutral: { neutral: 1 } }
+  cfg.balance.RESISTS_BY_TAG = {}
+  configSpy = vi.spyOn(configStore, 'CONFIG').mockReturnValue(cfg)
+  statusesSpy = vi.spyOn(registry, 'Statuses').mockReturnValue({})
+})
+
+afterEach(() => {
+  configSpy?.mockRestore()
+  statusesSpy?.mockRestore()
+  vi.restoreAllMocks()
+})
+
+describe('battle actions advanced behaviour', () => {
+  it('revives a fallen ally with revive effects', () => {
+    const player = makeActor('P1')
+    const ally = makeActor('P2', { hp: 0 })
+    ally.alive = false
+    const enemy = makeActor('E1')
+    const state = makeState([player, ally], [enemy])
+
+    const revive = makeSkill({
+      name: 'Revive',
+      targeting: makeSelector({ side: 'ally', mode: 'single', includeDead: true }),
+      effects: [flatEffect('revive', 40)],
+    })
+
+    const result = useSkill(state, revive, player.id, [ally.id])
+    expect(result.ok).toBe(true)
+    expect(state.actors[ally.id]?.alive).toBe(true)
+    expect(state.actors[ally.id]?.stats.hp).toBe(40)
+    expect(state.log.some((entry) => entry.includes('revived'))).toBe(true)
+  })
+
+  it('applies shields that absorb subsequent damage', () => {
+    const player = makeActor('P1')
+    const enemy = makeActor('E1')
+    const state = makeState([player], [enemy])
+
+    const barrier = makeSkill({
+      id: 'barrier',
+      name: 'Barrier',
+      targeting: makeSelector({ side: 'ally', mode: 'single' }),
+      effects: [{ ...flatEffect('shield', 30), shieldId: 'Barrier', selector: makeSelector({ side: 'ally' }) }],
+    })
+
+    const blast = makeSkill({
+      id: 'blast',
+      name: 'Blast',
+      effects: [flatEffect('damage', 20)],
+    })
+
+    const shieldResult = useSkill(state, barrier, player.id, [player.id])
+    expect(shieldResult.ok).toBe(true)
+    expect(state.shields[player.id]?.Barrier?.hp).toBe(30)
+
+    const damageResult = useSkill(state, blast, enemy.id, [player.id])
+    expect(damageResult.ok).toBe(true)
+    expect(state.actors[player.id]?.stats.hp).toBe(100)
+    expect(state.shields[player.id]?.Barrier?.hp).toBe(10)
+    expect(state.log.some((entry) => entry.includes('absorbed'))).toBe(true)
+  })
+
+  it('cleanses statuses with matching tags', () => {
+    statusesSpy?.mockReturnValue({
+      Burn: {
+        id: 'Burn',
+        name: 'Burn',
+        stackRule: 'renew',
+        maxStacks: 1,
+        durationTurns: 3,
+        tags: ['fire'],
+        modifiers: {},
+        hooks: { onApply: [], onTurnStart: [], onTurnEnd: [], onDealDamage: [], onTakeDamage: [], onExpire: [] },
+      },
+      Poison: {
+        id: 'Poison',
+        name: 'Poison',
+        stackRule: 'renew',
+        maxStacks: 1,
+        durationTurns: 3,
+        tags: ['toxin'],
+        modifiers: {},
+        hooks: { onApply: [], onTurnStart: [], onTurnEnd: [], onDealDamage: [], onTakeDamage: [], onExpire: [] },
+      },
+    })
+
+    const player = makeActor('P1')
+    const enemy = makeActor('E1')
+    const state = makeState([player], [enemy])
+
+    applyStatus(state, player.id, 'Burn', 3)
+    applyStatus(state, player.id, 'Poison', 3)
+    expect(state.actors[player.id]?.statuses).toHaveLength(2)
+
+    const cleanse = makeSkill({
+      name: 'Cleanse',
+      targeting: makeSelector({ side: 'ally', mode: 'single' }),
+      effects: [{ ...flatEffect('cleanseStatus', 0), cleanseTags: ['fire'] }],
+    })
+
+    const result = useSkill(state, cleanse, player.id, [player.id])
+    expect(result.ok).toBe(true)
+    expect(state.actors[player.id]?.statuses).toHaveLength(1)
+    expect(state.log.some((entry) => entry.includes('cleansed'))).toBe(true)
+  })
+
+  it('enforces charges on limited-use skills', () => {
+    const player = makeActor('P1')
+    const enemy = makeActor('E1')
+    const state = makeState([player], [enemy])
+
+    const limited = makeSkill({
+      id: 'limited',
+      name: 'Limited',
+      costs: { sta: 0, mp: 0, cooldown: 0, charges: 2 },
+      effects: [flatEffect('damage', 5)],
+    })
+
+    expect(useSkill(state, limited, player.id, [enemy.id]).ok).toBe(true)
+    expect(useSkill(state, limited, player.id, [enemy.id]).ok).toBe(true)
+    const third = useSkill(state, limited, player.id, [enemy.id])
+    expect(third.ok).toBe(false)
+    expect(state.charges[player.id]?.limited?.remaining).toBe(0)
+    expect(state.log[state.log.length - 1]).toContain('no charges')
+  })
+
+  it('respects cooldowns across turns', () => {
+    const player = makeActor('P1')
+    const enemy = makeActor('E1')
+    const state = makeState([player], [enemy])
+
+    const cooled = makeSkill({
+      id: 'cooldown',
+      name: 'Cooldown',
+      costs: { sta: 0, mp: 0, cooldown: 2 },
+      effects: [flatEffect('damage', 5)],
+    })
+
+    expect(useSkill(state, cooled, player.id, [enemy.id]).ok).toBe(true)
+    expect(useSkill(state, cooled, player.id, [enemy.id]).ok).toBe(false)
+    endTurn(state)
+    endTurn(state)
+    expect(useSkill(state, cooled, player.id, [enemy.id]).ok).toBe(true)
+  })
+
+  it('consumes items from inventory when used', () => {
+    const player = makeActor('P1')
+    const enemy = makeActor('E1')
+    const state = makeState([player], [enemy], [{ id: 'Potion', qty: 2 }])
+
+    const potion = makeItem({
+      id: 'Potion',
+      name: 'Potion',
+      targeting: makeSelector({ side: 'ally', mode: 'single' }),
+      effects: [flatEffect('heal', 20)],
+    })
+
+    expect(useItem(state, potion, player.id, [player.id]).ok).toBe(true)
+    expect(state.inventory.find((entry) => entry.id === 'Potion')?.qty).toBe(1)
+    expect(useItem(state, potion, player.id, [player.id]).ok).toBe(true)
+    expect(state.inventory.find((entry) => entry.id === 'Potion')).toBeUndefined()
+  })
+
+  it('runs onDealDamage hooks from statuses', () => {
+    statusesSpy?.mockReturnValue({
+      Fury: {
+        id: 'Fury',
+        name: 'Fury',
+        stackRule: 'renew',
+        maxStacks: 1,
+        durationTurns: 3,
+        tags: [],
+        modifiers: {},
+        hooks: {
+          onApply: [],
+          onTurnStart: [],
+          onTurnEnd: [],
+          onDealDamage: [flatEffect('heal', 10)],
+          onTakeDamage: [],
+          onExpire: [],
+        },
+      },
+    })
+
+    const player = makeActor('P1', { hp: 50 })
+    const enemy = makeActor('E1', { hp: 50 })
+    const state = makeState([player], [enemy])
+
+    applyStatus(state, player.id, 'Fury', 3, { sourceId: player.id })
+
+    const strike = makeSkill({
+      name: 'Strike',
+      effects: [flatEffect('damage', 15)],
+    })
+
+    useSkill(state, strike, player.id, [enemy.id])
+    expect(state.actors[player.id]?.stats.hp).toBe(60)
+    expect(state.log.some((entry) => entry.includes('recovers'))).toBe(true)
+  })
+
+  it('runs onTakeDamage hooks from statuses', () => {
+    statusesSpy?.mockReturnValue({
+      Thorns: {
+        id: 'Thorns',
+        name: 'Thorns',
+        stackRule: 'renew',
+        maxStacks: 1,
+        durationTurns: 3,
+        tags: [],
+        modifiers: {},
+        hooks: {
+          onApply: [],
+          onTurnStart: [],
+          onTurnEnd: [],
+          onDealDamage: [],
+          onTakeDamage: [flatEffect('damage', 5)],
+          onExpire: [],
+        },
+      },
+    })
+
+    const player = makeActor('P1')
+    const enemy = makeActor('E1', { hp: 50 })
+    const state = makeState([player], [enemy])
+
+    applyStatus(state, player.id, 'Thorns', 3, { sourceId: player.id })
+
+    const bite = makeSkill({
+      name: 'Bite',
+      effects: [flatEffect('damage', 10)],
+    })
+
+    useSkill(state, bite, enemy.id, [player.id])
+    expect(state.actors[enemy.id]?.stats.hp).toBe(45)
+    expect(state.log.some((entry) => entry.includes('suffers'))).toBe(true)
+  })
+
+  it('stores taunt targets and durations', () => {
+    const player = makeActor('P1')
+    const enemy = makeActor('E1')
+    const state = makeState([player], [enemy])
+
+    const provoke = makeSkill({
+      name: 'Provoke',
+      targeting: makeSelector({ side: 'enemy', mode: 'single' }),
+      effects: [{ ...flatEffect('taunt', 2), statusTurns: 2 }],
+    })
+
+    useSkill(state, provoke, player.id, [enemy.id])
+    expect(state.taunts[enemy.id]?.sourceId).toBe(player.id)
+    expect(state.taunts[enemy.id]?.turns).toBe(2)
+  })
+
+  it('allows fleeing to end the battle', () => {
+    const player = makeActor('P1')
+    const enemy = makeActor('E1')
+    const state = makeState([player], [enemy])
+
+    const flee = makeSkill({
+      name: 'Escape',
+      effects: [flatEffect('flee', 0)],
+    })
+
+    const result = useSkill(state, flee, player.id, [])
+    expect(result.ok).toBe(true)
+    expect(state.ended?.reason).toBe('fled')
+  })
+})

--- a/minmmo/tests/adapters.test.ts
+++ b/minmmo/tests/adapters.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULTS } from '@config/defaults';
+import { toEnemies, toItems, toSkills, toStatuses } from '@content/adapters';
+import type { GameConfig } from '@config/schema';
+import type { Actor } from '@engine/battle/types';
+
+function cloneDefaults(): GameConfig {
+  return JSON.parse(JSON.stringify(DEFAULTS)) as GameConfig;
+}
+
+describe('content adapters', () => {
+  const cfg: GameConfig = cloneDefaults();
+
+  cfg.skills = {
+    fireball: {
+      id: 'fireball',
+      type: 'skill',
+      name: 'Fireball',
+      targeting: { side: 'enemy', mode: 'single' },
+      effects: [
+        {
+          kind: 'damage',
+          valueType: 'formula',
+          formula: { expr: 'u.stats.atk * 4 - t.stats.def' },
+          min: 5,
+          max: 60,
+          canCrit: true,
+        },
+      ],
+      costs: { sta: 3 },
+    },
+  };
+
+  cfg.items = {
+    potion: {
+      id: 'potion',
+      type: 'item',
+      name: 'Potion',
+      targeting: { side: 'ally', mode: 'single' },
+      effects: [
+        {
+          kind: 'heal',
+          valueType: 'percent',
+          percent: 25,
+          min: 0,
+          max: 1,
+        },
+      ],
+      costs: { item: { id: 'potion', qty: 1 } },
+      consumable: true,
+    },
+  };
+
+  cfg.statuses = {
+    burn: {
+      id: 'burn',
+      name: 'Burn',
+      stackRule: 'stackCount',
+      maxStacks: 3,
+      durationTurns: 3,
+      tags: ['fire'],
+      modifiers: { shield: { id: 'burnShield', hp: 10 } },
+      hooks: {
+        onTurnEnd: [
+          { kind: 'damage', valueType: 'flat', amount: 5 },
+        ],
+      },
+    },
+  };
+
+  cfg.enemies = {
+    slime: {
+      name: 'Slime',
+      color: 0x00ff00,
+      base: { maxHp: 20, maxSta: 5, maxMp: 2, atk: 3, def: 1 },
+      scale: { maxHp: 4, maxSta: 1, maxMp: 0, atk: 1, def: 0 },
+      skills: ['fireball'],
+      items: [{ id: 'potion', qty: 1 }],
+      tags: ['slime'],
+    },
+  };
+
+  const makeActor = (overrides: Partial<Actor['stats']>): Actor => ({
+    id: 'hero',
+    name: 'Hero',
+    stats: {
+      maxHp: 100,
+      hp: 100,
+      maxSta: 50,
+      sta: 50,
+      maxMp: 30,
+      mp: 30,
+      atk: 10,
+      def: 5,
+      lv: 5,
+      xp: 0,
+      gold: 0,
+      ...overrides,
+    },
+    statuses: [],
+    alive: true,
+    tags: [],
+  });
+
+  it('compiles skills with formula values and clamps results', () => {
+    const skills = toSkills(cfg);
+    const fireball = skills.fireball;
+    expect(fireball).toBeDefined();
+    expect(fireball.effects[0].value.kind).toBe('formula');
+
+    const userHigh = makeActor({ atk: 20 });
+    const target = makeActor({ def: 0 });
+    const resolvedHigh = fireball.effects[0].value.resolve(userHigh, target, {});
+    expect(resolvedHigh).toBe(60);
+
+    const userLow = makeActor({ atk: 0 });
+    const resolvedLow = fireball.effects[0].value.resolve(userLow, target, {});
+    expect(resolvedLow).toBe(5);
+
+    expect(fireball.costs.sta).toBe(3);
+    expect(fireball.targeting.includeDead).toBe(false);
+  });
+
+  it('compiles items with percent values and normalized costs', () => {
+    const items = toItems(cfg);
+    const potion = items.potion;
+    expect(potion).toBeDefined();
+    expect(potion.effects[0].value.kind).toBe('percent');
+    expect(potion.effects[0].value.resolve(makeActor({}), makeActor({}), {})).toBeCloseTo(0.25);
+    expect(potion.costs.item).toEqual({ id: 'potion', qty: 1 });
+    expect(potion.consumable).toBe(true);
+  });
+
+  it('builds enemy factories that scale stats by level', () => {
+    const enemies = toEnemies(cfg);
+    const slimeFactory = enemies.slime;
+    const slime = slimeFactory(5);
+    expect(slime.stats.lv).toBe(5);
+    expect(slime.stats.maxHp).toBe(20 + 4 * 5);
+    expect(slime.stats.hp).toBe(slime.stats.maxHp);
+    expect(slime.tags).toEqual(['slime']);
+    expect(slime.meta?.skillIds).toEqual(['fireball']);
+  });
+
+  it('converts statuses into runtime templates with hooks', () => {
+    const statuses = toStatuses(cfg);
+    const burn = statuses.burn;
+    expect(burn.stackRule).toBe('stackCount');
+    expect(burn.maxStacks).toBe(3);
+    expect(burn.durationTurns).toBe(3);
+    expect(burn.tags).toEqual(['fire']);
+    expect(burn.modifiers?.shield?.id).toBe('burnShield');
+    expect(burn.hooks.onTurnEnd).toHaveLength(1);
+
+    const user = makeActor({});
+    const target = makeActor({});
+    expect(burn.hooks.onTurnEnd[0].value.resolve(user, target, {})).toBe(5);
+    expect(burn.hooks.onApply).toHaveLength(0);
+  });
+});

--- a/minmmo/tests/rules.test.ts
+++ b/minmmo/tests/rules.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RuntimeEffect, RuntimeSkill, RuntimeTargetSelector } from '@content/adapters'
+import { DEFAULTS } from '@config/defaults'
+import * as configStore from '@config/store'
+import { critChance, elementMult, hitChance, tagResistMult, type RuleContext } from '@engine/battle/rules'
+import type { Actor, BattleState } from '@engine/battle/types'
+
+function cloneDefaults() {
+  return JSON.parse(JSON.stringify(DEFAULTS))
+}
+
+function makeActor(id: string, overrides: Partial<Actor['stats']> = {}, tags: string[] = []): Actor {
+  return {
+    id,
+    name: id,
+    stats: {
+      maxHp: 100,
+      hp: 100,
+      maxSta: 20,
+      sta: 20,
+      maxMp: 10,
+      mp: 10,
+      atk: 10,
+      def: 5,
+      lv: 1,
+      xp: 0,
+      gold: 0,
+      ...overrides,
+    },
+    statuses: [],
+    alive: true,
+    tags,
+  }
+}
+
+function makeContext(): RuleContext {
+  const targeting: RuntimeTargetSelector = {
+    side: 'enemy',
+    mode: 'single',
+    includeDead: false,
+  }
+  const effect: RuntimeEffect = {
+    kind: 'damage',
+    value: {
+      kind: 'flat',
+      resolve: () => 0,
+    },
+    canCrit: false,
+    canMiss: false,
+  }
+  const action: RuntimeSkill = {
+    id: 'skill',
+    type: 'skill',
+    name: 'Skill',
+    targeting,
+    effects: [effect],
+    costs: { sta: 0, mp: 0, cooldown: 0 },
+    aiWeight: 1,
+  }
+  const state: BattleState = {
+    rngSeed: 1,
+    actors: {},
+    sidePlayer: [],
+    sideEnemy: [],
+    inventory: [],
+    order: [],
+    current: 0,
+    turn: 1,
+    log: [],
+  }
+  return { state, action, effect }
+}
+
+let configSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  configSpy = vi.spyOn(configStore, 'CONFIG')
+})
+
+afterEach(() => {
+  configSpy.mockRestore()
+  vi.restoreAllMocks()
+})
+
+function mockConfig(overrides: Partial<typeof DEFAULTS.balance>) {
+  const cfg = cloneDefaults()
+  cfg.balance = { ...cfg.balance, ...overrides }
+  configSpy.mockReturnValue(cfg)
+  return cfg
+}
+
+describe('battle rules', () => {
+  it('clamps hit chance within configured bounds', () => {
+    mockConfig({ BASE_HIT: 1.2, DODGE_FLOOR: 0.1, HIT_CEIL: 0.95 })
+    const ctx = makeContext()
+    const attacker = makeActor('A', { atk: 80, lv: 10 })
+    const defender = makeActor('B', { def: 5, lv: 1 })
+    expect(hitChance(attacker, defender, ctx)).toBeCloseTo(0.95)
+
+    mockConfig({ BASE_HIT: -0.4, DODGE_FLOOR: 0.15, HIT_CEIL: 0.9 })
+    const weakAttacker = makeActor('C', { atk: 1, lv: 1 })
+    const strongDefender = makeActor('D', { def: 50, lv: 20 })
+    expect(hitChance(weakAttacker, strongDefender, ctx)).toBeCloseTo(0.15)
+  })
+
+  it('returns crit chance influenced by stats and clamped to one', () => {
+    mockConfig({ BASE_CRIT: 0.4 })
+    const ctx = makeContext()
+    const attacker = makeActor('A', { atk: 120, lv: 50 })
+    const defender = makeActor('B', { def: 5, lv: 1 })
+    expect(critChance(attacker, defender, ctx)).toBeCloseTo(1)
+  })
+
+  it('applies element multipliers using the configured matrix', () => {
+    mockConfig({
+      ELEMENT_MATRIX: {
+        fire: { neutral: 1, slime: 2 },
+        neutral: { neutral: 1 },
+      },
+    })
+    const slime = makeActor('slime', {}, ['slime'])
+    expect(elementMult('fire', slime)).toBe(2)
+    expect(elementMult('ice', slime)).toBe(1)
+  })
+
+  it('multiplies tag resistances from the balance table', () => {
+    mockConfig({ RESISTS_BY_TAG: { slime: 0.5, armored: 0.8 } })
+    const target = makeActor('boss', {}, ['slime', 'armored'])
+    expect(tagResistMult(target)).toBeCloseTo(0.4)
+  })
+})

--- a/minmmo/tests/status.dot.test.ts
+++ b/minmmo/tests/status.dot.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RuntimeEffect, RuntimeStatusTemplate } from '@content/adapters'
+import { applyStatus, tickEndOfTurn } from '@engine/battle/status'
+import { createState } from '@engine/battle/state'
+import type { Actor, BattleState } from '@engine/battle/types'
+import { DEFAULTS } from '@config/defaults'
+import * as configStore from '@config/store'
+import * as registry from '@content/registry'
+
+function makeActor(id: string, overrides: Partial<Actor['stats']> = {}): Actor {
+  return {
+    id,
+    name: id,
+    stats: {
+      maxHp: 40,
+      hp: 40,
+      maxSta: 10,
+      sta: 10,
+      maxMp: 8,
+      mp: 8,
+      atk: 6,
+      def: 4,
+      lv: 1,
+      xp: 0,
+      gold: 0,
+      ...overrides,
+    },
+    statuses: [],
+    alive: true,
+    tags: ['player'],
+  }
+}
+
+function makeState(actor: Actor): BattleState {
+  return createState({
+    rngSeed: 123,
+    actors: { [actor.id]: actor },
+    sidePlayer: [actor.id],
+    sideEnemy: [],
+    inventory: [],
+  })
+}
+
+function flatEffect(kind: RuntimeEffect['kind'], amount: number): RuntimeEffect {
+  return {
+    kind,
+    value: {
+      kind: 'flat',
+      resolve: () => amount,
+      rawAmount: amount,
+    },
+    canCrit: false,
+    canMiss: false,
+  }
+}
+
+function statusTemplate(partial: Partial<RuntimeStatusTemplate> & { id: string }): RuntimeStatusTemplate {
+  return {
+    id: partial.id,
+    name: partial.name ?? partial.id,
+    desc: partial.desc,
+    icon: partial.icon,
+    tags: partial.tags ?? [],
+    stackRule: partial.stackRule ?? 'renew',
+    maxStacks: partial.maxStacks ?? 1,
+    durationTurns: partial.durationTurns ?? 1,
+    modifiers: partial.modifiers,
+    hooks: partial.hooks ?? {
+      onApply: [],
+      onTurnStart: [],
+      onTurnEnd: [],
+      onDealDamage: [],
+      onTakeDamage: [],
+      onExpire: [],
+    },
+  }
+}
+
+let configSpy: ReturnType<typeof vi.spyOn> | undefined
+let statusesSpy: ReturnType<typeof vi.spyOn> | undefined
+let registryMap: Record<string, RuntimeStatusTemplate>
+
+describe('status engine - damage over time', () => {
+  beforeEach(() => {
+    const cfg = JSON.parse(JSON.stringify(DEFAULTS))
+    cfg.balance.BASE_HIT = 1
+    cfg.balance.BASE_CRIT = 0
+    cfg.balance.DODGE_FLOOR = 0
+    cfg.balance.HIT_CEIL = 1
+    cfg.balance.ELEMENT_MATRIX = { neutral: { neutral: 1 } }
+    cfg.balance.RESISTS_BY_TAG = {}
+    configSpy = vi.spyOn(configStore, 'CONFIG').mockReturnValue(cfg)
+
+    registryMap = {}
+    statusesSpy = vi.spyOn(registry, 'Statuses').mockImplementation(() => registryMap)
+  })
+
+  afterEach(() => {
+    configSpy?.mockRestore()
+    statusesSpy?.mockRestore()
+    vi.restoreAllMocks()
+  })
+
+  it('ticks onTurnEnd damage and expires after the final turn', () => {
+    registryMap.burn = statusTemplate({
+      id: 'burn',
+      name: 'Burn',
+      durationTurns: 3,
+      hooks: {
+        onApply: [],
+        onTurnStart: [],
+        onTurnEnd: [flatEffect('damage', 5)],
+        onDealDamage: [],
+        onTakeDamage: [],
+        onExpire: [],
+      },
+    })
+
+    const actor = makeActor('P1', { hp: 30, maxHp: 30 })
+    const state = makeState(actor)
+
+    applyStatus(state, actor.id, 'burn', 3)
+    expect(actor.statuses).toHaveLength(1)
+    expect(actor.statuses[0]?.turns).toBe(3)
+
+    tickEndOfTurn(state, actor.id)
+    expect(actor.stats.hp).toBe(25)
+    expect(actor.statuses[0]?.turns).toBe(2)
+
+    tickEndOfTurn(state, actor.id)
+    expect(actor.stats.hp).toBe(20)
+    expect(actor.statuses[0]?.turns).toBe(1)
+
+    tickEndOfTurn(state, actor.id)
+    expect(actor.stats.hp).toBe(15)
+    expect(actor.statuses.length).toBe(0)
+    expect(state.log.some((line) => line.includes('expired'))).toBe(true)
+  })
+
+  it('renew stack rule refreshes duration', () => {
+    registryMap.freeze = statusTemplate({
+      id: 'freeze',
+      name: 'Freeze',
+      durationTurns: 4,
+      stackRule: 'renew',
+      hooks: {
+        onApply: [],
+        onTurnStart: [],
+        onTurnEnd: [],
+        onDealDamage: [],
+        onTakeDamage: [],
+        onExpire: [],
+      },
+    })
+
+    const actor = makeActor('P1')
+    const state = makeState(actor)
+
+    applyStatus(state, actor.id, 'freeze', 2)
+    tickEndOfTurn(state, actor.id)
+    expect(actor.statuses[0]?.turns).toBe(1)
+
+    applyStatus(state, actor.id, 'freeze', 4)
+    expect(actor.statuses[0]?.turns).toBe(4)
+    expect(state.log.filter((line) => line.includes('Freeze')).length).toBeGreaterThan(1)
+  })
+
+  it('stackCount rule increases stacks up to the template max', () => {
+    registryMap.poison = statusTemplate({
+      id: 'poison',
+      name: 'Poison',
+      durationTurns: 3,
+      stackRule: 'stackCount',
+      maxStacks: 3,
+      hooks: {
+        onApply: [],
+        onTurnStart: [],
+        onTurnEnd: [
+          {
+            kind: 'damage',
+            value: {
+              kind: 'flat',
+              resolve: (_u, _t, ctx) => (ctx.entry.stacks as number) * 2,
+            },
+            canCrit: false,
+            canMiss: false,
+          } as RuntimeEffect,
+        ],
+        onDealDamage: [],
+        onTakeDamage: [],
+        onExpire: [],
+      },
+    })
+
+    const actor = makeActor('P1', { hp: 40, maxHp: 40 })
+    const state = makeState(actor)
+
+    applyStatus(state, actor.id, 'poison', 3)
+    tickEndOfTurn(state, actor.id)
+    expect(actor.stats.hp).toBe(38)
+
+    applyStatus(state, actor.id, 'poison', 3)
+    expect(actor.statuses[0]?.stacks).toBe(2)
+    tickEndOfTurn(state, actor.id)
+    expect(actor.stats.hp).toBe(34)
+
+    applyStatus(state, actor.id, 'poison', 3)
+    applyStatus(state, actor.id, 'poison', 3)
+    expect(actor.statuses[0]?.stacks).toBe(3)
+  })
+})
+

--- a/minmmo/tests/targeting.advanced.test.ts
+++ b/minmmo/tests/targeting.advanced.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveTargets } from '@engine/battle/targeting'
+import type { Actor, BattleState } from '@engine/battle/types'
+import type { TargetSelector } from '@config/schema'
+
+const HERO_ID = 'hero'
+
+describe('resolveTargets - advanced modes', () => {
+  it('selects the highest metric targets when using highest mode', () => {
+    const state = createState()
+    state.actors.slime.stats.atk = 12
+    state.actors.goblin.stats.atk = 30
+
+    const selector: TargetSelector = { side: 'enemy', mode: 'highest', ofWhat: 'atk', count: 2 }
+    expect(resolveTargets(state, selector, HERO_ID)).toEqual(['goblin', 'slime'])
+  })
+
+  it('applies nested filter trees with includeDead to return condition targets', () => {
+    const state = createState()
+    state.actors.goblin.alive = false
+    state.actors.goblin.stats.hp = 0
+    state.actors.goblin.statuses.push({ id: 'Burn', turns: 2 })
+    state.actors.slime.statuses.push({ id: 'Freeze', turns: 1 })
+
+    const selector: TargetSelector = {
+      side: 'any',
+      mode: 'condition',
+      includeDead: true,
+      count: 1,
+      condition: {
+        all: [
+          {
+            any: [
+              { test: { key: 'hasStatus', op: 'eq', value: 'Burn' } },
+              { test: { key: 'hasStatus', op: 'eq', value: 'Poison' } },
+            ],
+          },
+          { not: { test: { key: 'tag', op: 'eq', value: 'player' } } },
+        ],
+      },
+    }
+
+    expect(resolveTargets(state, selector, HERO_ID)).toEqual(['goblin'])
+  })
+
+  it('limits the number of condition targets and honours any filters', () => {
+    const state = createState()
+    state.actors.mage.clazz = 'mage'
+    state.actors.slime.tags.push('boss')
+
+    const selector: TargetSelector = {
+      side: 'any',
+      mode: 'condition',
+      count: 2,
+      condition: {
+        any: [
+          { test: { key: 'tag', op: 'eq', value: 'boss' } },
+          { test: { key: 'clazz', op: 'eq', value: 'mage' } },
+        ],
+      },
+    }
+
+    expect(resolveTargets(state, selector, HERO_ID)).toEqual(['mage', 'slime'])
+  })
+})
+
+function createState(): BattleState {
+  const hero = makeActor(HERO_ID, { tags: ['player'], clazz: 'warrior' })
+  const mage = makeActor('mage', { tags: ['player'], clazz: 'sorcerer' })
+  const slime = makeActor('slime', { tags: ['enemy'] })
+  const goblin = makeActor('goblin', { tags: ['enemy'] })
+
+  return {
+    turn: 1,
+    order: [hero.id, mage.id, slime.id, goblin.id],
+    current: 0,
+    rngSeed: 123,
+    actors: {
+      [hero.id]: hero,
+      [mage.id]: mage,
+      [slime.id]: slime,
+      [goblin.id]: goblin,
+    },
+    sidePlayer: [hero.id, mage.id],
+    sideEnemy: [slime.id, goblin.id],
+    inventory: [],
+    log: [],
+  }
+}
+
+function makeActor(id: string, overrides: Partial<Actor> = {}): Actor {
+  const baseStats = {
+    maxHp: 100,
+    hp: 100,
+    maxSta: 50,
+    sta: 50,
+    maxMp: 30,
+    mp: 30,
+    atk: 10,
+    def: 5,
+    lv: 1,
+    xp: 0,
+    gold: 0,
+  }
+
+  return {
+    id,
+    name: overrides.name ?? id,
+    color: overrides.color,
+    clazz: overrides.clazz,
+    stats: { ...baseStats, ...(overrides.stats ?? {}) },
+    statuses: overrides.statuses ? overrides.statuses.map((entry) => ({ ...entry })) : [],
+    alive: overrides.alive ?? true,
+    tags: overrides.tags ? [...overrides.tags] : [],
+    meta: overrides.meta,
+  }
+}

--- a/minmmo/tests/targeting.basic.test.ts
+++ b/minmmo/tests/targeting.basic.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveTargets } from '@engine/battle/targeting'
+import type { Actor, BattleState } from '@engine/battle/types'
+import type { TargetSelector } from '@config/schema'
+
+describe('resolveTargets', () => {
+  it('selects the first enemy for single targeting', () => {
+    const state = createState()
+    const selector: TargetSelector = { side: 'enemy', mode: 'single' }
+    expect(resolveTargets(state, selector, 'hero')).toEqual(['slime'])
+  })
+
+  it('returns all allies for all mode', () => {
+    const state = createState()
+    const selector: TargetSelector = { side: 'ally', mode: 'all' }
+    expect(resolveTargets(state, selector, 'hero')).toEqual(['hero', 'mage'])
+  })
+
+  it('respects includeDead flag', () => {
+    const state = createState()
+    state.actors.mage.alive = false
+    state.actors.mage.stats.hp = 0
+
+    const withoutDead: TargetSelector = { side: 'ally', mode: 'all' }
+    expect(resolveTargets(state, withoutDead, 'hero')).toEqual(['hero'])
+
+    const withDead: TargetSelector = { side: 'ally', mode: 'all', includeDead: true }
+    expect(resolveTargets(state, withDead, 'hero')).toEqual(['hero', 'mage'])
+  })
+
+  it('returns the user for self targeting', () => {
+    const state = createState()
+    const selector: TargetSelector = { side: 'self', mode: 'self' }
+    expect(resolveTargets(state, selector, 'hero')).toEqual(['hero'])
+  })
+
+  it('combines sides when targeting any', () => {
+    const state = createState()
+    const selector: TargetSelector = { side: 'any', mode: 'all' }
+    expect(resolveTargets(state, selector, 'hero')).toEqual([
+      'hero',
+      'mage',
+      'slime',
+      'goblin',
+    ])
+  })
+
+  it('picks unique random targets and advances rngSeed', () => {
+    const state = createState()
+    const ogre = makeActor('ogre', { tags: ['enemy'] })
+    state.actors.ogre = ogre
+    state.sideEnemy.push('ogre')
+    state.order.push('ogre')
+    state.rngSeed = 7
+
+    const selector: TargetSelector = { side: 'enemy', mode: 'random', count: 2 }
+    const result = resolveTargets(state, selector, 'hero')
+
+    expect(result.length).toBe(2)
+    expect(new Set(result).size).toBe(2)
+    expect(state.rngSeed).not.toBe(7)
+    expect(result.every((id) => ['slime', 'goblin', 'ogre'].includes(id))).toBe(true)
+  })
+
+  it('filters candidates using condition mode', () => {
+    const state = createState()
+    state.actors.slime.tags.push('boss')
+
+    const selector: TargetSelector = {
+      side: 'enemy',
+      mode: 'condition',
+      condition: { test: { key: 'tag', op: 'eq', value: 'boss' } },
+    }
+
+    expect(resolveTargets(state, selector, 'hero')).toEqual(['slime'])
+  })
+
+  it('orders by metric when using lowest mode', () => {
+    const state = createState()
+    state.actors.slime.stats.hp = 10
+    state.actors.slime.stats.maxHp = 100
+    state.actors.goblin.stats.hp = 40
+    state.actors.goblin.stats.maxHp = 80
+
+    const selector: TargetSelector = { side: 'enemy', mode: 'lowest', ofWhat: 'hpPct', count: 2 }
+    expect(resolveTargets(state, selector, 'hero')).toEqual(['slime', 'goblin'])
+  })
+})
+
+function createState(): BattleState {
+  const hero = makeActor('hero', { tags: ['player'] })
+  const mage = makeActor('mage', { tags: ['player'] })
+  const slime = makeActor('slime', { tags: ['enemy'] })
+  const goblin = makeActor('goblin', { tags: ['enemy'] })
+
+  return {
+    turn: 1,
+    order: [hero.id, mage.id, slime.id, goblin.id],
+    current: 0,
+    rngSeed: 1,
+    actors: {
+      [hero.id]: hero,
+      [mage.id]: mage,
+      [slime.id]: slime,
+      [goblin.id]: goblin,
+    },
+    sidePlayer: [hero.id, mage.id],
+    sideEnemy: [slime.id, goblin.id],
+    inventory: [],
+    log: [],
+  }
+}
+
+function makeActor(id: string, overrides: Partial<Actor> = {}): Actor {
+  const baseStats = {
+    maxHp: 100,
+    hp: 100,
+    maxSta: 50,
+    sta: 50,
+    maxMp: 30,
+    mp: 30,
+    atk: 10,
+    def: 5,
+    lv: 1,
+    xp: 0,
+    gold: 0,
+  }
+
+  return {
+    id,
+    name: overrides.name ?? id,
+    color: overrides.color,
+    clazz: overrides.clazz,
+    stats: { ...baseStats, ...(overrides.stats ?? {}) },
+    statuses: overrides.statuses ? overrides.statuses.map((entry) => ({ ...entry })) : [],
+    alive: overrides.alive ?? true,
+    tags: overrides.tags ? [...overrides.tags] : [],
+    meta: overrides.meta,
+  }
+}

--- a/minmmo/tests/validate.test.ts
+++ b/minmmo/tests/validate.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { validateAndRepair } from '@content/validate';
+import { DEFAULTS } from '@config/defaults';
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+
+  get length() {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+}
+
+const brokenConfig = {
+  __version: 1,
+  classes: {
+    Knight: { maxHp: 60 },
+  },
+  classSkills: { Knight: null },
+  startItems: { Knight: null },
+  skills: {},
+  items: {},
+  statuses: {},
+  enemies: {},
+  npcs: {},
+};
+
+describe('validateAndRepair', () => {
+  beforeEach(() => {
+    (globalThis as any).localStorage = new MemoryStorage();
+  });
+
+  it('fills missing branches from defaults', () => {
+    const repaired = validateAndRepair(brokenConfig as any);
+    expect(repaired.classes.Knight.maxHp).toBe(60);
+    expect(repaired.classes.Knight.def).toBe(DEFAULTS.classes.Knight.def);
+    expect(repaired.classes.Rogue).toEqual(DEFAULTS.classes.Rogue);
+    expect(repaired.startItems.Knight).toEqual([]);
+    expect(repaired.classSkills.Knight).toEqual([]);
+  });
+
+  it('round-trips through import/export with repairs', async () => {
+    const storage = new MemoryStorage();
+    (globalThis as any).localStorage = storage;
+    vi.resetModules();
+    const store = await import('@config/store');
+    store.importConfig(JSON.stringify(brokenConfig));
+    const exported = JSON.parse(store.exportConfig());
+    expect(exported.classes.Knight.maxHp).toBe(60);
+    expect(exported.startItems.Knight).toEqual([]);
+    expect(exported.classSkills.Knight).toEqual([]);
+  });
+
+  it('repairs persisted config on load', async () => {
+    const storage = new MemoryStorage();
+    storage.setItem('minmmo:config', JSON.stringify({
+      __version: 1,
+      startItems: { Knight: null },
+    }));
+    (globalThis as any).localStorage = storage;
+    vi.resetModules();
+    const store = await import('@config/store');
+    const cfg = store.load();
+    expect(cfg.startItems.Knight).toEqual([]);
+    expect(cfg.classes).toEqual(DEFAULTS.classes);
+  });
+});

--- a/minmmo/vitest.config.ts
+++ b/minmmo/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+const r = (p: string) => resolve(fileURLToPath(new URL('.', import.meta.url)), p);
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@app': r('src/app'),
+      '@config': r('src/config'),
+      '@content': r('src/content'),
+      '@engine': r('src/engine'),
+      '@game': r('src/game'),
+      '@cms': r('src/cms'),
+    },
+  },
+  test: {
+    environment: 'node',
+    globals: true,
+    passWithNoTests: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add a save module that normalizes persisted profiles, merchant stocks, and world data for autosave support
- replace the overworld scene with class selection, equipment management, encounter launching, and merchant/trainer flows driven by config registries
- rebuild the battle scene to render resource bars, handle target selection, award loot/xp/gold, and persist results through the new autosave pipeline

## Testing
- npm run test
- timeout 5 npm run dev >/tmp/dev.log 2>&1

------
https://chatgpt.com/codex/tasks/task_e_68d09c3d491483248f6fa5f22764a852