### PR TITLE
Apply status modifiers to combat calculations

### DIFF
--- a/minmmo/src/engine/battle/rules.ts
+++ b/minmmo/src/engine/battle/rules.ts
@@ -12,7 +12,8 @@ export function hitChance(user: Actor, target: Actor, _ctx: RuleContext): number
   const { balance } = CONFIG()
   const levelDiff = (user.stats.lv - target.stats.lv) * 0.02
   const statDiff = (user.stats.atk - target.stats.def) * 0.01
-  const raw = balance.BASE_HIT + levelDiff + statDiff
+  const dodgePenalty = target.statusModifiers?.dodgeBonus ?? 0
+  const raw = balance.BASE_HIT + levelDiff + statDiff - dodgePenalty
   return clamp(raw, balance.DODGE_FLOOR, balance.HIT_CEIL)
 }
 
@@ -20,7 +21,8 @@ export function critChance(user: Actor, target: Actor, _ctx: RuleContext): numbe
   const { balance } = CONFIG()
   const levelBonus = Math.max(0, user.stats.lv - target.stats.lv) * 0.01
   const statBonus = Math.max(0, user.stats.atk - target.stats.def) * 0.005
-  const raw = balance.BASE_CRIT + levelBonus + statBonus
+  const critBonus = user.statusModifiers?.critChanceBonus ?? 0
+  const raw = balance.BASE_CRIT + levelBonus + statBonus + critBonus
   return clamp(raw, 0, 1)
 }
 

--- a/minmmo/src/engine/battle/types.ts
+++ b/minmmo/src/engine/battle/types.ts
@@ -2,7 +2,25 @@
 export type Targeting = 'self' | 'single' | 'all' | 'random' | 'lowest' | 'highest' | 'condition'
 export type Resource = 'hp' | 'sta' | 'mp'
 
-export interface Status { id: string; turns: number; stacks?: number }
+export interface StatusModifierSnapshot {
+  atk?: number
+  def?: number
+  damageTakenPct?: Record<string, number>
+  damageDealtPct?: Record<string, number>
+  resourceRegenPerTurn?: Partial<Record<Resource, number>>
+  dodgeBonus?: number
+  critChanceBonus?: number
+}
+
+export interface Status { id: string; turns: number; stacks?: number; appliedModifiers?: StatusModifierSnapshot }
+
+export interface ActorStatusModifierCache {
+  damageTakenPct: Record<string, number>
+  damageDealtPct: Record<string, number>
+  resourceRegenPerTurn: Partial<Record<Resource, number>>
+  dodgeBonus: number
+  critChanceBonus: number
+}
 
 export interface ShieldState {
   id: string
@@ -30,6 +48,7 @@ export interface Stats  {
 export interface Actor {
   id: string; name: string; color?: number; clazz?: string;
   stats: Stats; statuses: Status[]; alive: boolean; tags: string[];
+  statusModifiers?: ActorStatusModifierCache;
   meta?: { skillIds?: string[]; itemDrops?: { id:string; qty:number }[] };
 }
 


### PR DESCRIPTION
## Summary
- track snapshot contributions for status modifiers and maintain actor caches for shields, stat changes, damage modifiers, and bonuses
- apply the cached modifiers during damage, healing, resource, and status effect resolution while respecting dodge and crit bonuses
- extend status tests to verify attack buffs, defense buffs, and vulnerability statuses change battle outcomes as configured

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1d0a55ed08324b72b1501e35d7b82