### PR TITLE
Enforce taunt target selection across battle systems

### DIFF
--- a/minmmo/tests/battle.targeting.test.ts
+++ b/minmmo/tests/battle.targeting.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Actor, BattleState } from '@engine/battle/types';
+import type { TargetSelector } from '@config/schema';
+
+vi.mock('phaser', () => {
+  class Scene {
+    scale = { width: 0, height: 0, on: () => {}, off: () => {} };
+    add = {
+      text: () => ({
+        destroy: () => {},
+        setInteractive: () => ({ on: () => {} }),
+      }),
+      graphics: () => ({
+        clear: () => {},
+        fillStyle: () => {},
+        fillRect: () => {},
+        lineStyle: () => {},
+        strokeRect: () => {},
+      }),
+    };
+    cameras = { resize: () => {} };
+    events = { once: () => {} };
+    layout?: unknown;
+    constructor() {}
+  }
+
+  return {
+    default: {
+      Scene,
+      GameObjects: { Text: class {}, Graphics: class {} },
+      Structs: { Size: class {} },
+    },
+    Scene,
+    GameObjects: { Text: class {}, Graphics: class {} },
+    Structs: { Size: class {} },
+  };
+});
+
+function makeActor(id: string, overrides: Partial<Actor> = {}) {
+  const baseStats = {
+    maxHp: 100,
+    hp: 100,
+    maxSta: 50,
+    sta: 50,
+    maxMp: 30,
+    mp: 30,
+    atk: 10,
+    def: 5,
+    lv: 1,
+    xp: 0,
+    gold: 0,
+  };
+
+  return {
+    id,
+    name: overrides.name ?? id,
+    color: overrides.color,
+    clazz: overrides.clazz,
+    stats: { ...baseStats, ...(overrides.stats ?? {}) },
+    statuses: overrides.statuses ? overrides.statuses.map((entry) => ({ ...entry })) : [],
+    alive: overrides.alive ?? true,
+    tags: overrides.tags ? [...overrides.tags] : [],
+    meta: overrides.meta,
+  } satisfies Actor;
+}
+
+function createState(): BattleState {
+  const hero = makeActor('hero', { tags: ['player'] });
+  const mage = makeActor('mage', { tags: ['player'] });
+  const slime = makeActor('slime', { tags: ['enemy'] });
+  const goblin = makeActor('goblin', { tags: ['enemy'] });
+
+  return {
+    turn: 1,
+    order: [hero.id, mage.id, slime.id, goblin.id],
+    current: 0,
+    rngSeed: 1,
+    actors: {
+      [hero.id]: hero,
+      [mage.id]: mage,
+      [slime.id]: slime,
+      [goblin.id]: goblin,
+    },
+    sidePlayer: [hero.id, mage.id],
+    sideEnemy: [slime.id, goblin.id],
+    inventory: [],
+    log: [],
+    cooldowns: {},
+    charges: {},
+    shields: {},
+    taunts: {},
+  };
+}
+
+describe('Battle collectTargets', () => {
+  it('limits manual selection to an active taunt source', async () => {
+    const { Battle } = await import('@game/scenes/Battle');
+    const scene = new Battle();
+    (scene as any).state = createState();
+
+    const selector: TargetSelector = { side: 'enemy', mode: 'single' };
+
+    (scene as any).state.taunts.hero = { sourceId: 'goblin', turns: 1 };
+    const forced = (scene as any).collectTargets(selector, 'hero');
+    expect(forced).toEqual(['goblin']);
+
+    (scene as any).state.actors.goblin.alive = false;
+    const freed = (scene as any).collectTargets(selector, 'hero');
+    expect(freed).toEqual(['slime']);
+    expect((scene as any).state.taunts.hero).toBeUndefined();
+  });
+});

--- a/minmmo/tests/targeting.advanced.test.ts
+++ b/minmmo/tests/targeting.advanced.test.ts
@@ -86,6 +86,10 @@ function createState(): BattleState {
     sideEnemy: [slime.id, goblin.id],
     inventory: [],
     log: [],
+    cooldowns: {},
+    charges: {},
+    shields: {},
+    taunts: {},
   }
 }
 

--- a/minmmo/tests/targeting.basic.test.ts
+++ b/minmmo/tests/targeting.basic.test.ts
@@ -11,6 +11,25 @@ describe('resolveTargets', () => {
     expect(resolveTargets(state, selector, 'hero')).toEqual(['slime'])
   })
 
+  it('forces taunted actors to target the source enemy', () => {
+    const state = createState()
+    state.taunts.hero = { sourceId: 'goblin', turns: 1 }
+
+    const selector: TargetSelector = { side: 'enemy', mode: 'single' }
+    expect(resolveTargets(state, selector, 'hero')).toEqual(['goblin'])
+    expect(state.taunts.hero).toBeDefined()
+  })
+
+  it('clears taunts when the source is no longer valid', () => {
+    const state = createState()
+    state.taunts.hero = { sourceId: 'goblin', turns: 1 }
+    state.actors.goblin.alive = false
+
+    const selector: TargetSelector = { side: 'enemy', mode: 'single' }
+    expect(resolveTargets(state, selector, 'hero')).toEqual(['slime'])
+    expect(state.taunts.hero).toBeUndefined()
+  })
+
   it('returns all allies for all mode', () => {
     const state = createState()
     const selector: TargetSelector = { side: 'ally', mode: 'all' }
@@ -109,6 +128,10 @@ function createState(): BattleState {
     sideEnemy: [slime.id, goblin.id],
     inventory: [],
     log: [],
+    cooldowns: {},
+    charges: {},
+    shields: {},
+    taunts: {},
   }
 }
 


### PR DESCRIPTION
## Summary
- honor active taunts in resolveTargets by forcing the user to target the source or clearing invalid taunts
- mirror the taunt restriction in the battle UI so manual selection lists only the forced target
- expand targeting tests to cover taunt scenarios and add a UI-level test with a mocked Phaser scene

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1dd62dc3483249be78fcccb0a2d1a