### PR TITLE
Improve AI skill checks and enable status regen

### DIFF
--- a/minmmo/src/engine/battle/actions.ts
+++ b/minmmo/src/engine/battle/actions.ts
@@ -536,7 +536,7 @@ function modifierMultiplier(
   if (!map) {
     return 1
   }
-  const keys: string[] = ['all', ...categories]
+  const keys: string[] = ['all', ...categories.filter((key): key is string => Boolean(key))]
   let total = 0
   const seen = new Set<string>()
   for (const key of keys) {

--- a/minmmo/tsconfig.base.json
+++ b/minmmo/tsconfig.base.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "baseUrl": "./src",
+    "paths": {
+      "@app/*": ["app/*"],
+      "@config/*": ["config/*"],
+      "@content/*": ["content/*"],
+      "@engine/*": ["engine/*"],
+      "@game/*": ["game/*"],
+      "@cms/*": ["cms/*"]
+    }
+  },
+  "include": ["src", "vite.config.ts", "vitest.config.ts"]
+}

--- a/minmmo/tsconfig.json
+++ b/minmmo/tsconfig.json
@@ -1,26 +1,6 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "Bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx",
-    "strict": true,
-    "baseUrl": "./src",
-    "paths": {
-      "@app/*": ["app/*"],
-      "@config/*": ["config/*"],
-      "@content/*": ["content/*"],
-      "@engine/*": ["engine/*"],
-      "@game/*": ["game/*"],
-      "@cms/*": ["cms/*"]
-    },
-    "types": ["node", "vitest"]
-  },
-  "include": ["src", "vite.config.ts", "vitest.config.ts"]
+    "types": ["node"]
+  }
 }

--- a/minmmo/tsconfig.vitest.json
+++ b/minmmo/tsconfig.vitest.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node", "vitest"]
+  },
+  "include": ["src", "tests", "vite.config.ts", "vitest.config.ts"]
+}


### PR DESCRIPTION
## Summary
- ensure enemy skill selection respects per-skill canUse filters before committing to an action
- apply status-driven resource regeneration at end of turn using cached modifier data
- split the shared TypeScript config so production builds no longer depend on Vitest types while keeping a Vitest-specific project config

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d1e92052c88324a69851badad39366