### PR TITLE
Refine random targeting canUse validation

### DIFF
--- a/minmmo/src/game/scenes/Battle.ts
+++ b/minmmo/src/game/scenes/Battle.ts
@@ -3,7 +3,7 @@ import { CONFIG } from '@config/store';
 import { Items, Skills, Enemies, Statuses } from '@content/registry';
 import type { RuntimeItem, RuntimeSkill } from '@content/adapters';
 import { createState } from '@engine/battle/state';
-import { useItem, useSkill, endTurn, evaluateActionTargets } from '@engine/battle/actions';
+import { useItem, useSkill, endTurn, resolveActionTargetIds } from '@engine/battle/actions';
 import { resolveTargets } from '@engine/battle/targeting';
 import type { Actor, BattleState, InventoryEntry } from '@engine/battle/types';
 import {
@@ -449,7 +449,7 @@ export class Battle extends Phaser.Scene {
       return false;
     }
     const prevSeed = this.state.rngSeed;
-    const resolution = evaluateActionTargets(this.state, skill, actor);
+    const resolution = resolveActionTargetIds(this.state, skill, actor);
     this.state.rngSeed = prevSeed;
     return resolution.ok;
   }


### PR DESCRIPTION
## Summary
- add a shared helper to resolve action targets while honoring canUse filters without wasting RNG
- reuse the helper for skill execution and enemy AI validation so random targeting re-rolls from eligible candidates
- cover the regression with a random-target + canUse test that checks both player and AI paths

## Testing
- npm test -- tests/actions.full.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d1f2b899948324bd2052a45f5d3edb