### PR TITLE
Ensure canUse filters consider full random target pool

### DIFF
--- a/minmmo/src/game/scenes/Battle.ts
+++ b/minmmo/src/game/scenes/Battle.ts
@@ -3,7 +3,7 @@ import { CONFIG } from '@config/store';
 import { Items, Skills, Enemies, Statuses } from '@content/registry';
 import type { RuntimeItem, RuntimeSkill } from '@content/adapters';
 import { createState } from '@engine/battle/state';
-import { useItem, useSkill, endTurn, resolveActionTargetIds } from '@engine/battle/actions';
+import { useItem, useSkill, endTurn, collectUsableTargets } from '@engine/battle/actions';
 import { resolveTargets } from '@engine/battle/targeting';
 import type { Actor, BattleState, InventoryEntry } from '@engine/battle/types';
 import {
@@ -449,9 +449,9 @@ export class Battle extends Phaser.Scene {
       return false;
     }
     const prevSeed = this.state.rngSeed;
-    const resolution = resolveActionTargetIds(this.state, skill, actor);
+    const result = collectUsableTargets(this.state, skill, actor);
     this.state.rngSeed = prevSeed;
-    return resolution.ok;
+    return result.ok;
   }
 
   private renderState() {


### PR DESCRIPTION
## Summary
- add a collectUsableTargets helper that evaluates full candidate pools before sampling targets
- reuse the helper from action execution and the battle scene AI to avoid premature RNG consumption
- add regression coverage for random-target canUse skills to verify deterministic behaviour for players and enemies

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1f6ab4ba08324a2543a53b68eafd7