### PR TITLE
Add preventAction status hook effect

### DIFF
--- a/minmmo/src/config/schema.ts
+++ b/minmmo/src/config/schema.ts
@@ -18,6 +18,7 @@ export type EffectKind =
   | 'modifyStat' | 'shield' | 'taunt'
   | 'flee' | 'revive' | 'summon'
   | 'giveItem' | 'removeItem'
+  | 'preventAction'
 
 export type ValueType = 'flat' | 'percent' | 'formula'
 export interface Formula { expr: string }
@@ -30,6 +31,7 @@ export interface Effect {
   stat?: 'atk'|'def'|'maxHp'|'maxSta'|'maxMp'
   statusId?: StatusId; statusTurns?: number; cleanseTags?: string[]
   shieldId?: string
+  message?: string
   selector?: TargetSelector
   onlyIf?: Filter
 }

--- a/minmmo/src/content/adapters.ts
+++ b/minmmo/src/content/adapters.ts
@@ -266,6 +266,7 @@ function compileEffect(effect: Effect, scope: string): RuntimeEffect {
     statusTurns: effect.statusTurns,
     cleanseTags: effect.cleanseTags ? [...effect.cleanseTags] : undefined,
     shieldId: effect.shieldId,
+    message: effect.message,
     onlyIf: effect.onlyIf ? deepClone(effect.onlyIf) : undefined,
     selector,
     value,

--- a/minmmo/src/engine/battle/status.ts
+++ b/minmmo/src/engine/battle/status.ts
@@ -699,6 +699,11 @@ function applyHookEffect(
     return
   }
 
+  if (effect.kind === 'preventAction') {
+    ctx.control?.preventAction(effect.message)
+    return
+  }
+
   const resolved = resolveEffectValue(effect, source, target, ctx)
   if (resolved.kind === 'none') {
     return
@@ -885,4 +890,4 @@ function pushLog(state: BattleState, message: string) {
   state.log.push(message)
 }
 
-const SUPPORTED_KINDS = new Set<RuntimeEffect['kind']>(['damage', 'heal', 'resource'])
+const SUPPORTED_KINDS = new Set<RuntimeEffect['kind']>(['damage', 'heal', 'resource', 'preventAction'])


### PR DESCRIPTION
## Summary
- add a `preventAction` effect kind and optional message to status hook schemas and runtime adapters
- handle `preventAction` during status hook execution to call the control guard
- update status tests to build the new effect through the adapters and verify the turn skip and log message

## Testing
- `npm run test -- status.dot.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d20b09b8888324afa9f0cd9784b84f