### PR TITLE
Allow preventAction effects in admin portal

### DIFF
--- a/minmmo/src/cms/AdminPortal.tsx
+++ b/minmmo/src/cms/AdminPortal.tsx
@@ -62,6 +62,7 @@ const effectKinds = [
   'summon',
   'giveItem',
   'removeItem',
+  'preventAction',
 ] as const satisfies readonly EffectKind[];
 const valueTypes = ['flat', 'percent', 'formula'] as const satisfies readonly ValueType[];
 const resources = ['hp', 'sta', 'mp'] as const satisfies readonly Resource[];

--- a/minmmo/src/content/validate.ts
+++ b/minmmo/src/content/validate.ts
@@ -34,6 +34,7 @@ const effectKinds = [
   'summon',
   'giveItem',
   'removeItem',
+  'preventAction',
 ] as const;
 const targetSides = ['self', 'ally', 'enemy', 'any'] as const;
 const targetModes = ['self', 'single', 'all', 'random', 'lowest', 'highest', 'condition'] as const;


### PR DESCRIPTION
## Summary
- add preventAction to the admin portal effect kind options
- preserve preventAction effects when validating content configs

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d21d11bd888324873b3e3ab869f0b8