### PR TITLE
Style battle log with card layout

### DIFF
--- a/minmmo/src/game/scenes/BattleLogPlayer.ts
+++ b/minmmo/src/game/scenes/BattleLogPlayer.ts
@@ -12,7 +12,7 @@ export class BattleLogPlayer {
 
   private readonly scene: Phaser.Scene;
 
-  private readonly maxLines: number;
+  private maxLines: number;
 
   private readonly charDelay: number;
 
@@ -101,6 +101,19 @@ export class BattleLogPlayer {
       });
     }
     return this.drainPromise;
+  }
+
+  setMaxLines(lines: number) {
+    const normalized = Math.max(1, Math.floor(lines));
+    if (normalized === this.maxLines) {
+      return;
+    }
+    this.maxLines = normalized;
+    if (this.displayed.length > this.maxLines) {
+      this.displayed = this.displayed.slice(-this.maxLines);
+    }
+    const partial = this.playing && this.currentIndex > 0 ? this.currentLine.slice(0, this.currentIndex) : undefined;
+    this.refreshText(partial);
   }
 
   private requestSkip() {


### PR DESCRIPTION
## Summary
- style the battle log as a card with a label, monospaced text, and padded content
- compute the log card metrics in the scene layout and redraw the accent background
- allow the BattleLogPlayer to update its maximum lines when the layout changes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d31da4d20c832484df5f4f266fd889