### PR TITLE
Refine battle target selection flow

### DIFF
--- a/minmmo/src/game/scenes/Battle.ts
+++ b/minmmo/src/game/scenes/Battle.ts
@@ -356,9 +356,10 @@ export class Battle extends Phaser.Scene {
     });
     hitArea.on('pointerdown', () => {
       if (!this.targetSelectionActive) return;
-      if (!this.targetPickCallback) return;
       if (!this.targetCandidates.has(card.actorId)) return;
-      this.targetPickCallback(card.actorId);
+      const callback = this.targetPickCallback;
+      if (!callback) return;
+      callback(card.actorId);
     });
 
     return card;
@@ -1340,34 +1341,37 @@ export class Battle extends Phaser.Scene {
     if (!candidates.length) {
       return;
     }
+
     this.targetSelectionActive = true;
     this.targetCandidates.clear();
     for (const id of candidates) {
       this.targetCandidates.add(id);
     }
     this.targetPickCallback = onPick;
+
     const cancelButton = this.createTargetButton('cancel', 'Cancel');
     cancelButton.hitArea.on('pointerdown', () => {
       this.clearTargetPicker();
     });
     this.targetButtons.push(cancelButton);
+
     this.refreshCommandAvailability();
     this.renderState();
     this.layoutUi();
   }
 
   private clearTargetPicker() {
-    const wasActive = this.targetSelectionActive || this.targetButtons.length > 0 || this.targetCandidates.size > 0;
-    for (const entry of this.targetButtons) entry.container.destroy(true);
+    for (const entry of this.targetButtons) {
+      entry.container.destroy(true);
+    }
     this.targetButtons = [];
-    this.targetSelectionActive = false;
     this.targetCandidates.clear();
     this.targetPickCallback = undefined;
+    this.targetSelectionActive = false;
+
     this.refreshCommandAvailability();
-    if (wasActive) {
-      this.renderState();
-      this.layoutUi();
-    }
+    this.renderState();
+    this.layoutUi();
   }
 
   private handleResize(gameSize: Phaser.Structs.Size) {


### PR DESCRIPTION
## Summary
- populate the target selection candidate set and show only a cancel entry while storing the target pick callback
- ensure clearing the target picker tears down UI, resets state, and re-renders immediately
- guard card pointer interactions so only eligible targets invoke the stored pick callback

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d34cffc8d48324839626a07077241a