### PR TITLE
Fix battle UI reset between fights

### DIFF
--- a/minmmo/src/game/scenes/Battle.ts
+++ b/minmmo/src/game/scenes/Battle.ts
@@ -175,7 +175,41 @@ export class Battle extends Phaser.Scene {
     super('Battle');
   }
 
+  private resetUiState() {
+    for (const button of this.commandTabButtons) {
+      button.container.destroy(true);
+    }
+    this.commandTabButtons = [];
+
+    for (const row of this.commandRows) {
+      row.container.destroy(true);
+    }
+    this.commandRows = [];
+
+    for (const button of this.commandFooterButtons) {
+      button.container.destroy(true);
+    }
+    this.commandFooterButtons = [];
+
+    for (const button of this.targetButtons) {
+      button.container.destroy(true);
+    }
+    this.targetButtons = [];
+    this.targetCandidates.clear();
+
+    if (this.commandPanelBackground) {
+      this.commandPanelBackground.destroy();
+      this.commandPanelBackground = undefined;
+    }
+
+    if (this.commandContentBackground) {
+      this.commandContentBackground.destroy();
+      this.commandContentBackground = undefined;
+    }
+  }
+
   create(data: BattleInitData) {
+    this.resetUiState();
     this.outcomeHandled = false;
     this.profile = data.profile;
     this.world = data.world;
@@ -240,6 +274,7 @@ export class Battle extends Phaser.Scene {
     this.scale.on('resize', this.handleResize, this);
     this.events.once('shutdown', () => {
       this.scale.off('resize', this.handleResize, this);
+      this.resetUiState();
     });
   }
 


### PR DESCRIPTION
## Summary
- add a reset helper to clean up battle command, target, and background UI artifacts
- invoke the reset when the battle scene starts and shuts down so a new fight rebuilds valid game objects

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d46fbb99a483248652076a66392754