### PR TITLE
Scale player movement by frame time

### DIFF
--- a/minmmo/src/game/scenes/Overworld.ts
+++ b/minmmo/src/game/scenes/Overworld.ts
@@ -105,7 +105,7 @@ export class Overworld extends Phaser.Scene {
   }
 
   update(_time: number, delta: number) {
-    this.updatePlayerMovement();
+    this.updatePlayerMovement(delta);
     this.updateMerchant(delta);
   }
 
@@ -239,7 +239,7 @@ export class Overworld extends Phaser.Scene {
     }
   }
 
-  private updatePlayerMovement() {
+  private updatePlayerMovement(delta: number) {
     if (!this.player || !this.keys) return;
     let moveX = 0;
     let moveY = 0;
@@ -252,8 +252,9 @@ export class Overworld extends Phaser.Scene {
 
     if (moveX || moveY) {
       const length = Math.hypot(moveX, moveY) || 1;
-      const vx = (moveX / length) * PLAYER_SPEED;
-      const vy = (moveY / length) * PLAYER_SPEED;
+      const frameSpeed = PLAYER_SPEED * (delta / 1000);
+      const vx = (moveX / length) * frameSpeed;
+      const vy = (moveY / length) * frameSpeed;
       this.player.setVelocity(vx, vy);
     }
   }


### PR DESCRIPTION
## Summary
- scale the overworld player's velocity by the frame delta before updating Matter physics
- keep diagonal input normalized so collisions and motion behave consistently at slower speeds

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d611fbb5a083249276adb8e31ba459