### PR TITLE
Fix tileset normalization helper usage

### DIFF
--- a/minmmo/src/game/scenes/Overworld.ts
+++ b/minmmo/src/game/scenes/Overworld.ts
@@ -122,6 +122,46 @@ export class Overworld extends Phaser.Scene {
     }
   }
 
+  private normalizeTilesetData(cacheKey: string) {
+    const cachedMap = this.cache.tilemap.get(cacheKey);
+    const tilesets = cachedMap?.data?.tilesets;
+
+    if (!Array.isArray(tilesets)) {
+      return;
+    }
+
+    for (const entry of tilesets) {
+      if (!entry || typeof entry !== 'object') {
+        continue;
+      }
+
+      const tileset = entry as {
+        tileproperties?: Record<string, unknown>;
+        tileProperties?: unknown[];
+      } & Record<string, unknown>;
+
+      if (!tileset.tileproperties || typeof tileset.tileproperties !== 'object') {
+        tileset.tileproperties = {};
+      }
+
+      if (!Array.isArray(tileset.tileProperties)) {
+        const normalized: unknown[] = [];
+        for (const key of Object.keys(tileset.tileproperties)) {
+          const index = Number(key);
+          if (Number.isNaN(index)) {
+            continue;
+          }
+          normalized[index] = tileset.tileproperties[key];
+        }
+        tileset.tileProperties = normalized;
+      }
+
+      if (!Array.isArray(tileset.tileProperties)) {
+        tileset.tileProperties = [];
+      }
+    }
+  }
+
   private markCollidableTiles(map: Phaser.Tilemaps.Tilemap) {
     for (const tileset of map.tilesets) {
       const data = (tileset as any).tileData as Record<string, any> | undefined;


### PR DESCRIPTION
## Summary
- add a tileset normalization helper in the Overworld scene to convert cached tile properties into array form before loading the map

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6131df0f08324a10735310e21ac55