### PR TITLE
Guard minimap cleanup when cameras are missing

### DIFF
--- a/minmmo/src/game/scenes/Overworld.ts
+++ b/minmmo/src/game/scenes/Overworld.ts
@@ -820,7 +820,7 @@ export class Overworld extends Phaser.Scene {
     this.scale.off(Phaser.Scale.Events.RESIZE, this.handleScaleResize, this);
 
     if (this.minimapCamera) {
-      this.cameras.remove(this.minimapCamera, true);
+      this.cameras?.remove?.(this.minimapCamera, true);
       this.minimapCamera = undefined;
     }
 
@@ -828,10 +828,10 @@ export class Overworld extends Phaser.Scene {
     this.minimapBackdrop = undefined;
 
     if (this.minimapMarker) {
-      const mainCamera = this.cameras.main as Phaser.Cameras.Scene2D.Camera & {
+      const mainCamera = this.cameras?.main as (Phaser.Cameras.Scene2D.Camera & {
         removeFromRenderList?: (gameObject: Phaser.GameObjects.GameObject) => void;
-      };
-      mainCamera.removeFromRenderList?.(this.minimapMarker);
+      }) | undefined;
+      mainCamera?.removeFromRenderList?.(this.minimapMarker);
       this.minimapMarker.destroy();
       this.minimapMarker = undefined;
     }


### PR DESCRIPTION
## Summary
- guard minimap cleanup against missing camera instances so scene shutdown won't throw

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d9724ed4c88324bc5b8505765e8925