### PR TITLE
Track defeated spawn zones in save data

### DIFF
--- a/minmmo/src/game/save.ts
+++ b/minmmo/src/game/save.ts
@@ -29,6 +29,7 @@ export interface WorldState {
   turn: number;
   lastLocation?: string;
   lastOverworldPosition?: { x: number; y: number };
+  defeatedSpawnZones: string[];
 }
 
 export interface CharacterRecord {
@@ -75,7 +76,7 @@ const LEGACY_CHARACTER_ID = 'solo-hero';
 const storage: Storage | undefined = typeof localStorage === 'undefined' ? undefined : localStorage;
 
 function defaultWorld(): WorldState {
-  return { merchants: {}, flags: {}, turn: 0 };
+  return { merchants: {}, flags: {}, turn: 0, defeatedSpawnZones: [] };
 }
 
 export function createDefaultWorld(): WorldState {
@@ -286,6 +287,16 @@ function sanitizeWorld(input: any): WorldState {
       input && typeof input.lastOverworldPosition === 'object'
         ? sanitizePoint(input.lastOverworldPosition)
         : undefined,
+    defeatedSpawnZones: Array.isArray(input?.defeatedSpawnZones)
+      ? Array.from(
+          new Set(
+            input.defeatedSpawnZones
+              .filter((id: unknown): id is string => typeof id === 'string')
+              .map((id: string) => id.trim())
+              .filter((id) => id.length > 0),
+          ),
+        )
+      : [],
   };
 }
 

--- a/minmmo/src/game/scenes/Battle.ts
+++ b/minmmo/src/game/scenes/Battle.ts
@@ -21,6 +21,7 @@ interface BattleInitData {
   world: WorldState;
   enemyId: string;
   enemyLevel: number;
+  spawnZoneId?: string;
 }
 
 interface LabelBackgroundElements {
@@ -170,6 +171,7 @@ export class Battle extends Phaser.Scene {
   private lastAnnouncedActor?: string;
   private lastStartOfTurn?: { actorId: string; index: number; turn: number; prevented: boolean };
   private autoSkippingPlayer = false;
+  private encounterZoneId?: string;
 
   constructor() {
     super('Battle');
@@ -213,6 +215,7 @@ export class Battle extends Phaser.Scene {
     this.outcomeHandled = false;
     this.profile = data.profile;
     this.world = data.world;
+    this.encounterZoneId = typeof data.spawnZoneId === 'string' ? data.spawnZoneId : undefined;
     const enemyFactory = Enemies()[data.enemyId];
     if (!enemyFactory) {
       this.scene.start('Overworld', { summary: [`Enemy ${data.enemyId} is not configured.`] });
@@ -2225,6 +2228,14 @@ export class Battle extends Phaser.Scene {
       summary.push(`Victory! +${rewards.xp} XP, +${rewards.gold} gold.`);
       if (rewards.loot.length) {
         summary.push(`Loot: ${rewards.loot.map((l) => `${l.id} x${l.qty}`).join(', ')}`);
+      }
+      if (this.encounterZoneId) {
+        if (!Array.isArray(this.world.defeatedSpawnZones)) {
+          this.world.defeatedSpawnZones = [];
+        }
+        if (!this.world.defeatedSpawnZones.includes(this.encounterZoneId)) {
+          this.world.defeatedSpawnZones.push(this.encounterZoneId);
+        }
       }
     } else if (reason === 'defeat') {
       const economy: any = balance.ECONOMY ?? {};

--- a/minmmo/src/game/scenes/Overworld.ts
+++ b/minmmo/src/game/scenes/Overworld.ts
@@ -329,6 +329,9 @@ export class Overworld extends Phaser.Scene {
       return;
     }
 
+    const world = getActiveWorld();
+    const defeated = new Set(world?.defeatedSpawnZones ?? []);
+
     for (const [layerName, kind] of Object.entries(ENCOUNTER_LAYER_MAP)) {
       const layer = this.map.getObjectLayer(layerName);
       if (!layer || !Array.isArray(layer.objects)) {
@@ -341,7 +344,12 @@ export class Overworld extends Phaser.Scene {
           continue;
         }
 
-        const id = `${layerName}-${object.id ?? this.spawnZones.length}`;
+        const rawId =
+          object.id ?? object.name ?? `${Math.round(object.x ?? 0)}-${Math.round(object.y ?? 0)}`;
+        const id = `${layerName}-${rawId}`;
+        if (defeated.has(id)) {
+          continue;
+        }
         this.spawnZones.push({ id, kind, polygon });
       }
     }
@@ -593,6 +601,7 @@ export class Overworld extends Phaser.Scene {
       world,
       enemyId: config.enemyId,
       enemyLevel: config.enemyLevel,
+      spawnZoneId: zone.id,
     });
   }
 

--- a/minmmo/tests/save.auth.test.ts
+++ b/minmmo/tests/save.auth.test.ts
@@ -34,6 +34,7 @@ function buildWorld(): WorldState {
     merchants: {},
     flags: {},
     turn: 0,
+    defeatedSpawnZones: [],
   };
 }
 


### PR DESCRIPTION
## Summary
- extend the world save data to remember defeated spawn zones
- record defeated zones on battle victory and skip respawning them in the overworld

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d99af5c49c83248f6dc999c331d8e0