### PR TITLE
Add pause menu overlay and hide auth sidebar in overworld

### DIFF
--- a/minmmo/src/app/game/PauseMenu.tsx
+++ b/minmmo/src/app/game/PauseMenu.tsx
@@ -1,0 +1,53 @@
+interface PauseMenuProps {
+  visible: boolean;
+  onResume(): void;
+  onSave(): void;
+  onLogout(): void;
+  statusMessage?: string;
+  statusTone?: 'info' | 'success' | 'error';
+}
+
+export function PauseMenu({
+  visible,
+  onResume,
+  onSave,
+  onLogout,
+  statusMessage,
+  statusTone = 'info',
+}: PauseMenuProps) {
+  if (!visible) {
+    return null;
+  }
+
+  const statusClasses = ['pause-menu__status'];
+  if (statusTone === 'success') {
+    statusClasses.push('pause-menu__status--success');
+  } else if (statusTone === 'error') {
+    statusClasses.push('pause-menu__status--error');
+  }
+
+  return (
+    <div className="pause-overlay" role="dialog" aria-modal="true" aria-label="Pause menu">
+      <div className="pause-menu">
+        <header>
+          <h2>Game Paused</h2>
+          <p className="pause-menu__subtitle">Take a breather and choose your next action.</p>
+        </header>
+        <div className={statusClasses.join(' ')}>
+          {statusMessage ?? '\u00A0'}
+        </div>
+        <div className="pause-menu__actions">
+          <button type="button" onClick={onResume}>
+            Resume Adventure
+          </button>
+          <button type="button" className="ghost" onClick={onSave}>
+            Save Game
+          </button>
+          <button type="button" className="ghost danger" onClick={onLogout}>
+            Log Out
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/minmmo/src/game/save.ts
+++ b/minmmo/src/game/save.ts
@@ -293,7 +293,7 @@ function sanitizeWorld(input: any): WorldState {
             input.defeatedSpawnZones
               .filter((id: unknown): id is string => typeof id === 'string')
               .map((id: string) => id.trim())
-              .filter((id) => id.length > 0),
+              .filter((id: string) => id.length > 0),
           ),
         )
       : [],

--- a/minmmo/src/index.css
+++ b/minmmo/src/index.css
@@ -59,6 +59,75 @@ body {
   flex: 1;
 }
 
+.pause-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(5, 8, 18, 0.78);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  box-sizing: border-box;
+  backdrop-filter: blur(2px);
+}
+
+.pause-menu {
+  background: #141830;
+  border: 1px solid #20264a;
+  border-radius: 18px;
+  padding: 28px 32px;
+  width: min(360px, 100%);
+  box-shadow: 0 28px 80px rgba(6, 8, 16, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  text-align: center;
+}
+
+.pause-menu h2 {
+  margin: 0 0 4px;
+}
+
+.pause-menu__subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.pause-menu__status {
+  min-height: 20px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.pause-menu__status--success {
+  color: #71d675;
+}
+
+.pause-menu__status--error {
+  color: #ff6b6b;
+}
+
+.pause-menu__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pause-menu__actions button {
+  width: 100%;
+  justify-content: center;
+}
+
+.pause-menu__actions .ghost {
+  border-color: #303769;
+}
+
+.pause-menu__actions .ghost.danger {
+  border-color: #ff6b6b;
+  color: #ff6b6b;
+}
+
 .game-placeholder {
   position: absolute;
   top: 50%;


### PR DESCRIPTION
## Summary
- hide the AuthApp sidebar whenever the overworld scene is active so the canvas can span the full width
- add a pause overlay component that appears on ESC with resume, save, and logout actions
- emit overworld lifecycle events to drive the pause menu and hook save requests into the existing save helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d99e0d945c83249d7f5934f274b6c6