### PR TITLE
Implement networked persistence for game saves

### DIFF
--- a/minmmo/package-lock.json
+++ b/minmmo/package-lock.json
@@ -8,6 +8,7 @@
       "name": "minmmo-skeleton",
       "version": "0.1.0",
       "dependencies": {
+        "bcryptjs": "^3.0.2",
         "express": "^4.19.2",
         "pg": "^8.12.0",
         "phaser": "^3.90.0",
@@ -1780,6 +1781,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/body-parser": {

--- a/minmmo/package.json
+++ b/minmmo/package.json
@@ -12,6 +12,7 @@
     "db:migrate": "tsx server/scripts/runMigrations.ts"
   },
   "dependencies": {
+    "bcryptjs": "^3.0.2",
     "express": "^4.19.2",
     "pg": "^8.12.0",
     "phaser": "^3.90.0",

--- a/minmmo/server/migrations/002_game_saves.sql
+++ b/minmmo/server/migrations/002_game_saves.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS account_credentials (
+  id TEXT PRIMARY KEY,
+  password_hash TEXT NOT NULL,
+  active_character_id TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS account_characters (
+  id TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL REFERENCES account_credentials(id) ON DELETE CASCADE,
+  profile JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_selected_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS character_world_states (
+  character_id TEXT PRIMARY KEY REFERENCES account_characters(id) ON DELETE CASCADE,
+  state JSONB NOT NULL DEFAULT '{}'::jsonb,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS character_inventories (
+  character_id TEXT PRIMARY KEY REFERENCES account_characters(id) ON DELETE CASCADE,
+  items JSONB NOT NULL DEFAULT '[]'::jsonb,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_account_characters_account_id ON account_characters(account_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'account_credentials_active_character_fk'
+  ) THEN
+    ALTER TABLE account_credentials
+      ADD CONSTRAINT account_credentials_active_character_fk
+      FOREIGN KEY (active_character_id)
+      REFERENCES account_characters(id)
+      ON DELETE SET NULL;
+  END IF;
+END$$;

--- a/minmmo/server/routes/accounts.ts
+++ b/minmmo/server/routes/accounts.ts
@@ -1,101 +1,221 @@
 import { Router } from 'express'
+import bcrypt from 'bcryptjs'
 import { pool } from '../db.js'
 
 const router = Router()
 
+interface AccountSummaryRow {
+  id: string
+  character_count: string | number | null
+  active_character_id: string | null
+  created_at: Date | string | null
+  updated_at: Date | string | null
+}
+
+interface CharacterRow {
+  id: string
+  account_id: string
+  profile: any
+  created_at: Date | string | null
+  updated_at: Date | string | null
+  last_selected_at: Date | string | null
+  world: any
+  inventory: any
+}
+
+function toEpoch(value: Date | string | null): number {
+  if (!value) return Date.now()
+  const date = value instanceof Date ? value : new Date(value)
+  const epoch = Number.isFinite(date.valueOf()) ? date.valueOf() : Date.now()
+  return epoch
+}
+
+function mapAccountSummary(row: AccountSummaryRow) {
+  return {
+    id: row.id,
+    characterCount: Number(row.character_count ?? 0),
+    activeCharacterId: row.active_character_id ?? undefined,
+    createdAt: toEpoch(row.created_at ?? null),
+    updatedAt: toEpoch(row.updated_at ?? null),
+  }
+}
+
+function mapCharacter(row: CharacterRow) {
+  const profile = row.profile && typeof row.profile === 'object' ? { ...row.profile } : {}
+  const inventory = Array.isArray(row.inventory) ? row.inventory : []
+  return {
+    id: row.id,
+    profile: { ...profile, inventory },
+    world: row.world && typeof row.world === 'object' ? row.world : {},
+    createdAt: toEpoch(row.created_at ?? null),
+    updatedAt: toEpoch(row.updated_at ?? null),
+    lastSelectedAt: row.last_selected_at ? toEpoch(row.last_selected_at) : undefined,
+  }
+}
+
 router.get('/', async (_req, res, next) => {
   try {
-    const { rows } = await pool.query(
-      'SELECT id, username, email, created_at FROM accounts ORDER BY created_at DESC'
+    const { rows } = await pool.query<AccountSummaryRow>(
+      `SELECT a.id, a.active_character_id, a.created_at, a.updated_at, COUNT(c.id) AS character_count
+       FROM account_credentials a
+       LEFT JOIN account_characters c ON c.account_id = a.id
+       GROUP BY a.id
+       ORDER BY a.created_at ASC`
     )
-    res.json(rows)
-  } catch (error) {
-    next(error)
-  }
-})
-
-router.get('/:id', async (req, res, next) => {
-  try {
-    const id = Number.parseInt(req.params.id, 10)
-    if (Number.isNaN(id)) {
-      res.status(400).json({ message: 'Invalid account id' })
-      return
-    }
-    const { rows } = await pool.query(
-      'SELECT id, username, email, created_at FROM accounts WHERE id = $1',
-      [id]
-    )
-    if (rows.length === 0) {
-      res.status(404).json({ message: 'Account not found' })
-      return
-    }
-    res.json(rows[0])
+    res.json(rows.map(mapAccountSummary))
   } catch (error) {
     next(error)
   }
 })
 
 router.post('/', async (req, res, next) => {
-  const { username, email, passwordHash } = req.body ?? {}
-  if (!username || !email || !passwordHash) {
-    res.status(400).json({ message: 'username, email, and passwordHash are required' })
+  const id = typeof req.body?.id === 'string' ? req.body.id.trim() : ''
+  const password = typeof req.body?.password === 'string' ? req.body.password : ''
+  if (!id || !password) {
+    res.status(400).json({ message: 'id and password are required' })
     return
   }
   try {
-    const { rows } = await pool.query(
-      'INSERT INTO accounts (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id, username, email, created_at',
-      [username, email, passwordHash]
+    const hashed = await bcrypt.hash(password, 12)
+    const { rows } = await pool.query<AccountSummaryRow>(
+      `INSERT INTO account_credentials (id, password_hash)
+       VALUES ($1, $2)
+       RETURNING id, active_character_id, created_at, updated_at, 0 AS character_count`,
+      [id, hashed]
     )
-    res.status(201).json(rows[0])
-  } catch (error) {
+    res.status(201).json({
+      id: rows[0].id,
+      characters: {},
+      activeCharacterId: rows[0].active_character_id ?? undefined,
+      createdAt: toEpoch(rows[0].created_at ?? null),
+      updatedAt: toEpoch(rows[0].updated_at ?? null),
+    })
+  } catch (error: any) {
+    if (error?.code === '23505') {
+      res.status(409).json({ message: 'Account already exists' })
+      return
+    }
     next(error)
   }
 })
 
-router.put('/:id', async (req, res, next) => {
-  const { email, passwordHash } = req.body ?? {}
-  if (typeof email === 'undefined' && typeof passwordHash === 'undefined') {
-    res.status(400).json({ message: 'At least one field (email or passwordHash) must be provided' })
+router.post('/authenticate', async (req, res, next) => {
+  const id = typeof req.body?.id === 'string' ? req.body.id.trim() : ''
+  const password = typeof req.body?.password === 'string' ? req.body.password : ''
+  if (!id) {
+    res.status(400).json({ success: false, message: 'Account id is required' })
     return
   }
   try {
-    const id = Number.parseInt(req.params.id, 10)
-    if (Number.isNaN(id)) {
-      res.status(400).json({ message: 'Invalid account id' })
-      return
-    }
-    const { rows } = await pool.query(
-      `UPDATE accounts
-       SET email = COALESCE($2, email),
-           password_hash = COALESCE($3, password_hash),
-           updated_at = NOW()
-       WHERE id = $1
-       RETURNING id, username, email, created_at, updated_at`,
-      [id, email, passwordHash]
+    const { rows } = await pool.query<{ password_hash: string }>(
+      'SELECT password_hash FROM account_credentials WHERE id = $1',
+      [id]
     )
     if (rows.length === 0) {
-      res.status(404).json({ message: 'Account not found' })
+      res.json({ success: false })
       return
     }
-    res.json(rows[0])
+    const ok = await bcrypt.compare(password, rows[0].password_hash)
+    res.json({ success: ok })
   } catch (error) {
     next(error)
   }
 })
 
-router.delete('/:id', async (req, res, next) => {
+router.post('/:accountId/selection', async (req, res, next) => {
+  const accountId = typeof req.params.accountId === 'string' ? req.params.accountId.trim() : ''
+  if (!accountId) {
+    res.status(400).json({ message: 'Invalid account id' })
+    return
+  }
+  const characterId =
+    typeof req.body?.characterId === 'string' && req.body.characterId
+      ? req.body.characterId.trim()
+      : null
   try {
-    const id = Number.parseInt(req.params.id, 10)
-    if (Number.isNaN(id)) {
-      res.status(400).json({ message: 'Invalid account id' })
-      return
-    }
-    const { rowCount } = await pool.query('DELETE FROM accounts WHERE id = $1', [id])
-    if (rowCount === 0) {
+    const accountResult = await pool.query('SELECT 1 FROM account_credentials WHERE id = $1', [accountId])
+    if (accountResult.rowCount === 0) {
       res.status(404).json({ message: 'Account not found' })
       return
     }
+    await pool.query(
+      `UPDATE account_credentials
+       SET active_character_id = $2,
+           updated_at = NOW()
+       WHERE id = $1`,
+      [accountId, characterId]
+    )
+    if (characterId) {
+      const { rowCount } = await pool.query(
+        `UPDATE account_characters
+         SET last_selected_at = NOW(),
+             updated_at = NOW()
+         WHERE id = $1 AND account_id = $2`,
+        [characterId, accountId]
+      )
+      if (rowCount === 0) {
+        res.status(404).json({ message: 'Character not found for account' })
+        return
+      }
+    }
     res.status(204).send()
+  } catch (error) {
+    next(error)
+  }
+})
+
+router.get('/:accountId/characters', async (req, res, next) => {
+  const accountId = typeof req.params.accountId === 'string' ? req.params.accountId.trim() : ''
+  if (!accountId) {
+    res.status(400).json({ message: 'Invalid account id' })
+    return
+  }
+  try {
+    const accountExists = await pool.query('SELECT 1 FROM account_credentials WHERE id = $1', [accountId])
+    if (accountExists.rowCount === 0) {
+      res.status(404).json({ message: 'Account not found' })
+      return
+    }
+    const { rows } = await pool.query<CharacterRow>(
+      `SELECT c.id, c.account_id, c.profile, c.created_at, c.updated_at, c.last_selected_at,
+              COALESCE(w.state, '{}'::jsonb) AS world,
+              COALESCE(i.items, '[]'::jsonb) AS inventory
+       FROM account_characters c
+       LEFT JOIN character_world_states w ON w.character_id = c.id
+       LEFT JOIN character_inventories i ON i.character_id = c.id
+       WHERE c.account_id = $1
+       ORDER BY COALESCE(c.last_selected_at, to_timestamp(0)) DESC, c.updated_at DESC`,
+      [accountId]
+    )
+    res.json(rows.map(mapCharacter))
+  } catch (error) {
+    next(error)
+  }
+})
+
+router.get('/:accountId/characters/:characterId', async (req, res, next) => {
+  const accountId = typeof req.params.accountId === 'string' ? req.params.accountId.trim() : ''
+  const characterId = typeof req.params.characterId === 'string' ? req.params.characterId.trim() : ''
+  if (!accountId || !characterId) {
+    res.status(400).json({ message: 'Invalid account or character id' })
+    return
+  }
+  try {
+    const { rows } = await pool.query<CharacterRow>(
+      `SELECT c.id, c.account_id, c.profile, c.created_at, c.updated_at, c.last_selected_at,
+              COALESCE(w.state, '{}'::jsonb) AS world,
+              COALESCE(i.items, '[]'::jsonb) AS inventory
+       FROM account_characters c
+       LEFT JOIN character_world_states w ON w.character_id = c.id
+       LEFT JOIN character_inventories i ON i.character_id = c.id
+       WHERE c.account_id = $1 AND c.id = $2`,
+      [accountId, characterId]
+    )
+    if (rows.length === 0) {
+      res.status(404).json({ message: 'Character not found' })
+      return
+    }
+    res.json(mapCharacter(rows[0]))
   } catch (error) {
     next(error)
   }

--- a/minmmo/src/game/api/saveClient.ts
+++ b/minmmo/src/game/api/saveClient.ts
@@ -1,0 +1,119 @@
+import type { PlayerProfile, WorldState } from '../save'
+
+declare const __MINMMO_API_BASE__: string | undefined
+
+type RequestOptions = RequestInit & { expect?: 'json' | 'empty' }
+
+let apiBase = resolveDefaultBase()
+
+function resolveDefaultBase(): string {
+  if (typeof __MINMMO_API_BASE__ === 'string' && __MINMMO_API_BASE__) {
+    return normalizeBase(__MINMMO_API_BASE__)
+  }
+  if (typeof window !== 'undefined' && window.location) {
+    const { protocol, host } = window.location
+    if (protocol === 'https:') {
+      return `https://${host}`
+    }
+    if (host) {
+      return `https://${host}`
+    }
+  }
+  return 'https://localhost:3001'
+}
+
+function normalizeBase(input: string): string {
+  const trimmed = input.trim()
+  if (!trimmed) {
+    return 'https://localhost:3001'
+  }
+  const url = new URL(trimmed, 'https://localhost')
+  url.protocol = 'https:'
+  return url.origin
+}
+
+function resolveUrl(path: string): string {
+  const base = new URL(apiBase)
+  base.protocol = 'https:'
+  const target = new URL(path.replace(/^(\/)+/, ''), base)
+  target.protocol = 'https:'
+  return target.toString()
+}
+
+async function request<T = unknown>(path: string, options: RequestOptions = {}): Promise<T> {
+  const { expect = 'json', headers, ...rest } = options
+  const init: RequestInit = {
+    credentials: 'include',
+    ...rest,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(headers ?? {}),
+    },
+  }
+  const response = await fetch(resolveUrl(path), init)
+  if (!response.ok) {
+    const message = `Request failed with status ${response.status}`
+    throw new Error(message)
+  }
+  if (expect === 'empty' || response.status === 204) {
+    return undefined as T
+  }
+  return (await response.json()) as T
+}
+
+export function setSaveApiBase(base: string) {
+  apiBase = normalizeBase(base)
+}
+
+export async function listAccountsRequest(): Promise<unknown> {
+  return request('/api/accounts')
+}
+
+export async function createAccountRequest(id: string, password: string): Promise<unknown> {
+  return request('/api/accounts', {
+    method: 'POST',
+    body: JSON.stringify({ id, password }),
+  })
+}
+
+export async function authenticateAccountRequest(
+  id: string,
+  password: string,
+): Promise<{ success: boolean }> {
+  return request('/api/accounts/authenticate', {
+    method: 'POST',
+    body: JSON.stringify({ id, password }),
+  })
+}
+
+export async function selectActiveCharacterRequest(accountId: string, characterId: string | null) {
+  await request(`/api/accounts/${encodeURIComponent(accountId)}/selection`, {
+    method: 'POST',
+    body: JSON.stringify({ characterId }),
+    expect: 'empty',
+  })
+}
+
+export async function listCharactersRequest(accountId: string): Promise<unknown> {
+  return request(`/api/accounts/${encodeURIComponent(accountId)}/characters`)
+}
+
+export async function getCharacterRequest(accountId: string, characterId: string): Promise<unknown> {
+  return request(
+    `/api/accounts/${encodeURIComponent(accountId)}/characters/${encodeURIComponent(characterId)}`,
+  )
+}
+
+export async function upsertCharacterRequest(
+  accountId: string,
+  payload: { id?: string; profile: PlayerProfile; world: WorldState },
+): Promise<unknown> {
+  const target = payload.id
+    ? `/api/characters/${encodeURIComponent(payload.id)}`
+    : '/api/characters'
+  const method = payload.id ? 'PUT' : 'POST'
+  return request(target, {
+    method,
+    body: JSON.stringify({ ...payload, accountId }),
+  })
+}

--- a/minmmo/src/game/save.ts
+++ b/minmmo/src/game/save.ts
@@ -1,230 +1,109 @@
-import type { InventoryEntry, Stats } from '@engine/battle/types';
+import type { InventoryEntry, Stats } from '@engine/battle/types'
+import {
+  authenticateAccountRequest,
+  createAccountRequest,
+  getCharacterRequest,
+  listAccountsRequest,
+  listCharactersRequest,
+  selectActiveCharacterRequest,
+  upsertCharacterRequest,
+} from './api/saveClient'
 
 export interface PlayerProfile {
-  name: string;
-  clazz: string;
-  level: number;
-  xp: number;
-  gold: number;
-  stats: Stats;
-  unlockedSkills: string[];
-  equippedSkills: string[];
-  inventory: InventoryEntry[];
+  name: string
+  clazz: string
+  level: number
+  xp: number
+  gold: number
+  stats: Stats
+  unlockedSkills: string[]
+  equippedSkills: string[]
+  inventory: InventoryEntry[]
 }
 
 export interface MerchantStockEntry {
-  id: string;
-  qty: number;
-  basePrice: number;
+  id: string
+  qty: number
+  basePrice: number
 }
 
 export interface MerchantState {
-  stock: MerchantStockEntry[];
-  restockIn: number;
+  stock: MerchantStockEntry[]
+  restockIn: number
 }
 
 export interface WorldState {
-  merchants: Record<string, MerchantState>;
-  flags: Record<string, boolean>;
-  turn: number;
-  lastLocation?: string;
-  lastOverworldPosition?: { x: number; y: number };
-  defeatedSpawnZones: string[];
+  merchants: Record<string, MerchantState>
+  flags: Record<string, boolean>
+  turn: number
+  lastLocation?: string
+  lastOverworldPosition?: { x: number; y: number }
+  defeatedSpawnZones: string[]
 }
 
 export interface CharacterRecord {
-  id: string;
-  profile: PlayerProfile;
-  world: WorldState;
-  createdAt: number;
-  updatedAt: number;
-  lastSelectedAt?: number;
+  id: string
+  profile: PlayerProfile
+  world: WorldState
+  createdAt: number
+  updatedAt: number
+  lastSelectedAt?: number
 }
 
 export interface AccountRecord {
-  id: string;
-  passwordHash?: string;
-  characters: Record<string, CharacterRecord>;
-  activeCharacterId?: string;
-  createdAt: number;
-  updatedAt: number;
-}
-
-export interface SaveData {
-  version: number;
-  accounts: Record<string, AccountRecord>;
-  activeAccountId?: string;
+  id: string
+  characters: Record<string, CharacterRecord>
+  activeCharacterId?: string
+  createdAt: number
+  updatedAt: number
 }
 
 export interface AccountSummary {
-  id: string;
-  characterCount: number;
-  activeCharacterId?: string;
-  createdAt: number;
-  updatedAt: number;
+  id: string
+  characterCount: number
+  activeCharacterId?: string
+  createdAt: number
+  updatedAt: number
 }
 
 export interface ActiveSelection {
-  accountId?: string;
-  characterId?: string;
-}
-
-const SAVE_KEY = 'minmmo:save';
-const CURRENT_VERSION = 2;
-const LEGACY_ACCOUNT_ID = 'solo';
-const LEGACY_CHARACTER_ID = 'solo-hero';
-const storage: Storage | undefined = typeof localStorage === 'undefined' ? undefined : localStorage;
-
-function defaultWorld(): WorldState {
-  return { merchants: {}, flags: {}, turn: 0, defeatedSpawnZones: [] };
-}
-
-export function createDefaultWorld(): WorldState {
-  return defaultWorld();
-}
-
-function defaultSave(): SaveData {
-  return { version: CURRENT_VERSION, accounts: {} };
+  accountId?: string
+  characterId?: string
 }
 
 function deepClone<T>(value: T): T {
   if (Array.isArray(value)) {
-    return value.map((entry) => deepClone(entry)) as unknown as T;
+    return value.map((entry) => deepClone(entry)) as unknown as T
   }
   if (value && typeof value === 'object') {
-    const result: Record<string, unknown> = {};
+    const result: Record<string, unknown> = {}
     for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
-      result[key] = deepClone(entry);
+      result[key] = deepClone(entry)
     }
-    return result as T;
+    return result as T
   }
-  return value;
+  return value
 }
 
-let cache: SaveData = defaultSave();
-
-(function init() {
-  if (!storage) {
-    return;
-  }
-  try {
-    const raw = storage.getItem(SAVE_KEY);
-    if (!raw) {
-      return;
-    }
-    const parsed = JSON.parse(raw);
-    cache = normalizeSave(parsed);
-  } catch {
-    cache = defaultSave();
-  }
-})();
-
-function normalizeSave(input: any): SaveData {
-  if (input && typeof input === 'object' && input.accounts && typeof input.accounts === 'object') {
-    return sanitizeAccountsSave(input);
-  }
-  return migrateLegacySave(input);
+function defaultWorld(): WorldState {
+  return { merchants: {}, flags: {}, turn: 0, defeatedSpawnZones: [] }
 }
 
-function sanitizeAccountsSave(input: any): SaveData {
-  const accountsInput = input.accounts ?? {};
-  const accounts: Record<string, AccountRecord> = {};
-  for (const [rawId, account] of Object.entries(accountsInput as Record<string, any>)) {
-    const id = String(rawId ?? '').trim();
-    if (!id) continue;
-    const sanitized = sanitizeAccount(id, account);
-    accounts[sanitized.id] = sanitized;
-  }
-
-  let activeAccountId: string | undefined;
-  if (typeof input?.activeAccountId === 'string' && accounts[input.activeAccountId]) {
-    activeAccountId = input.activeAccountId;
-  }
-
-  return {
-    version: Number.isFinite(input?.version) ? Number(input.version) : CURRENT_VERSION,
-    accounts,
-    activeAccountId,
-  };
+export function createDefaultWorld(): WorldState {
+  return defaultWorld()
 }
 
-function migrateLegacySave(input: any): SaveData {
-  const profile = input && typeof input.profile === 'object' ? sanitizeProfile(input.profile) : undefined;
-  const world = sanitizeWorld(input && typeof input.world === 'object' ? input.world : {});
-  if (!profile) {
-    return defaultSave();
+function sanitizePoint(value: any): { x: number; y: number } | undefined {
+  const x = Number(value?.x)
+  const y = Number(value?.y)
+  if (!Number.isFinite(x) || !Number.isFinite(y)) {
+    return undefined
   }
-
-  const character: CharacterRecord = {
-    id: LEGACY_CHARACTER_ID,
-    profile,
-    world,
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
-  };
-
-  const account: AccountRecord = {
-    id: LEGACY_ACCOUNT_ID,
-    passwordHash: undefined,
-    characters: { [character.id]: character },
-    activeCharacterId: character.id,
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
-  };
-
-  return {
-    version: CURRENT_VERSION,
-    accounts: { [account.id]: account },
-    activeAccountId: account.id,
-  };
-}
-
-function sanitizeAccount(id: string, input: any): AccountRecord {
-  const characters: Record<string, CharacterRecord> = {};
-  if (input && typeof input.characters === 'object') {
-    for (const [rawId, character] of Object.entries(input.characters as Record<string, any>)) {
-      const charId = String(rawId ?? '').trim();
-      if (!charId) continue;
-      const sanitized = sanitizeCharacter(charId, character);
-      characters[sanitized.id] = sanitized;
-    }
-  }
-
-  let activeCharacterId: string | undefined;
-  if (typeof input?.activeCharacterId === 'string' && characters[input.activeCharacterId]) {
-    activeCharacterId = input.activeCharacterId;
-  }
-
-  const createdAt = Number.isFinite(input?.createdAt) ? Number(input.createdAt) : Date.now();
-  const updatedAt = Number.isFinite(input?.updatedAt) ? Number(input.updatedAt) : createdAt;
-  const passwordHash = typeof input?.passwordHash === 'string' && input.passwordHash ? input.passwordHash : undefined;
-
-  return {
-    id,
-    passwordHash,
-    characters,
-    activeCharacterId,
-    createdAt,
-    updatedAt,
-  };
-}
-
-function sanitizeCharacter(id: string, input: any): CharacterRecord {
-  const createdAt = Number.isFinite(input?.createdAt) ? Number(input.createdAt) : Date.now();
-  const updatedAt = Number.isFinite(input?.updatedAt) ? Number(input.updatedAt) : createdAt;
-  const lastSelectedAt = Number.isFinite(input?.lastSelectedAt) ? Number(input.lastSelectedAt) : undefined;
-  return {
-    id,
-    profile: sanitizeProfile(input?.profile ?? {}),
-    world: sanitizeWorld(input?.world ?? {}),
-    createdAt,
-    updatedAt,
-    lastSelectedAt,
-  };
+  return { x, y }
 }
 
 function sanitizeProfile(input: any): PlayerProfile {
-  const stats = (input?.stats ?? {}) as Partial<Stats>;
+  const stats = (input?.stats ?? {}) as Partial<Stats>
   const safeStats: Stats = {
     maxHp: Number(stats.maxHp) || 1,
     hp: Number(stats.hp) || Number(stats.maxHp) || 1,
@@ -237,7 +116,7 @@ function sanitizeProfile(input: any): PlayerProfile {
     lv: Number(stats.lv) || Number(input?.level) || 1,
     xp: Number(stats.xp) || Number(input?.xp) || 0,
     gold: Number(stats.gold) || Number(input?.gold) || 0,
-  };
+  }
   return {
     name: typeof input?.name === 'string' && input.name ? input.name : 'Adventurer',
     clazz: typeof input?.clazz === 'string' && input.clazz ? input.clazz : 'Knight',
@@ -256,14 +135,14 @@ function sanitizeProfile(input: any): PlayerProfile {
           .map((entry: any) => ({ id: String(entry?.id ?? ''), qty: Number(entry?.qty) || 0 }))
           .filter((entry: InventoryEntry) => entry.id && entry.qty > 0)
       : [],
-  };
+  }
 }
 
 function sanitizeWorld(input: any): WorldState {
-  const merchants: Record<string, MerchantState> = {};
+  const merchants: Record<string, MerchantState> = {}
   if (input && typeof input.merchants === 'object') {
     for (const [id, state] of Object.entries(input.merchants as Record<string, any>)) {
-      if (!id) continue;
+      if (!id) continue
       merchants[id] = {
         stock: Array.isArray(state?.stock)
           ? state.stock
@@ -275,7 +154,7 @@ function sanitizeWorld(input: any): WorldState {
               .filter((entry: MerchantStockEntry) => entry.id && entry.qty > 0)
           : [],
         restockIn: Math.max(0, Number(state?.restockIn) || 0),
-      };
+      }
     }
   }
   return {
@@ -297,269 +176,260 @@ function sanitizeWorld(input: any): WorldState {
           ),
         )
       : [],
-  };
-}
-
-function sanitizePoint(value: any): { x: number; y: number } | undefined {
-  const x = Number(value?.x);
-  const y = Number(value?.y);
-  if (!Number.isFinite(x) || !Number.isFinite(y)) {
-    return undefined;
-  }
-  return { x, y };
-}
-
-function persist() {
-  if (!storage) return;
-  try {
-    storage.setItem(SAVE_KEY, JSON.stringify(cache));
-  } catch {
-    // ignore quota errors
   }
 }
 
-function hashPassword(password: string): string {
-  const str = String(password ?? '');
-  let hash = 2166136261;
-  for (let i = 0; i < str.length; i += 1) {
-    hash ^= str.charCodeAt(i);
-    hash = Math.imul(hash, 16777619);
-  }
-  return `h${(hash >>> 0).toString(16).padStart(8, '0')}`;
-}
-
-function ensureAccount(accountId: string): AccountRecord {
-  const id = String(accountId ?? '').trim();
+function sanitizeCharacterRecord(input: any): CharacterRecord {
+  const id = typeof input?.id === 'string' ? input.id.trim() : ''
   if (!id) {
-    throw new Error('Account ID is required.');
+    throw new Error('Character id is required.')
   }
-  const account = cache.accounts[id];
-  if (!account) {
-    throw new Error(`Account ${id} does not exist.`);
-  }
-  return account;
-}
-
-function generateCharacterId(account: AccountRecord): string {
-  const base = `char-${Math.random().toString(36).slice(2, 8)}`;
-  if (!account.characters[base]) return base;
-  let i = 1;
-  while (account.characters[`${base}-${i}`]) {
-    i += 1;
-  }
-  return `${base}-${i}`;
-}
-
-function getActiveAccount(): AccountRecord | undefined {
-  if (!cache.activeAccountId) return undefined;
-  return cache.accounts[cache.activeAccountId];
-}
-
-function getActiveCharacterRecord(): CharacterRecord | undefined {
-  const account = getActiveAccount();
-  if (!account || !account.activeCharacterId) return undefined;
-  return account.characters[account.activeCharacterId];
-}
-
-export function getSave(): SaveData {
-  return deepClone(cache);
-}
-
-export function listAccounts(): AccountSummary[] {
-  const entries = Object.values(cache.accounts).map((account) => ({
-    id: account.id,
-    characterCount: Object.keys(account.characters).length,
-    activeCharacterId: account.activeCharacterId,
-    createdAt: account.createdAt,
-    updatedAt: account.updatedAt,
-  }));
-  return entries.sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id));
-}
-
-export function createAccount(accountId: string, password: string): AccountRecord {
-  const id = String(accountId ?? '').trim();
-  if (!id) {
-    throw new Error('Account ID is required.');
-  }
-  if (cache.accounts[id]) {
-    throw new Error('Account already exists.');
-  }
-  const now = Date.now();
-  const account: AccountRecord = {
+  const createdAt = Number.isFinite(Number(input?.createdAt)) ? Number(input.createdAt) : Date.now()
+  const updatedAt = Number.isFinite(Number(input?.updatedAt)) ? Number(input.updatedAt) : createdAt
+  const lastSelectedAt = Number.isFinite(Number(input?.lastSelectedAt))
+    ? Number(input.lastSelectedAt)
+    : undefined
+  return {
     id,
-    passwordHash: hashPassword(password),
-    characters: {},
-    activeCharacterId: undefined,
-    createdAt: now,
-    updatedAt: now,
-  };
-  cache.accounts[id] = account;
-  cache.activeAccountId = id;
-  persist();
-  return deepClone(account);
+    profile: sanitizeProfile(input?.profile ?? {}),
+    world: sanitizeWorld(input?.world ?? {}),
+    createdAt,
+    updatedAt,
+    lastSelectedAt,
+  }
 }
 
-export function authenticateAccount(accountId: string, password: string): boolean {
-  const id = String(accountId ?? '').trim();
+function sanitizeAccountRecord(input: any): AccountRecord {
+  const id = typeof input?.id === 'string' ? input.id.trim() : ''
   if (!id) {
-    return false;
+    throw new Error('Account id is required.')
   }
-  const account = cache.accounts[id];
-  if (!account) {
-    return false;
+  const createdAt = Number.isFinite(Number(input?.createdAt)) ? Number(input.createdAt) : Date.now()
+  const updatedAt = Number.isFinite(Number(input?.updatedAt)) ? Number(input.updatedAt) : createdAt
+  const activeCharacterId =
+    typeof input?.activeCharacterId === 'string' && input.activeCharacterId
+      ? input.activeCharacterId
+      : undefined
+  const characters: Record<string, CharacterRecord> = {}
+  if (input && typeof input.characters === 'object') {
+    for (const [key, value] of Object.entries(input.characters as Record<string, any>)) {
+      try {
+        const record = sanitizeCharacterRecord({ ...value, id: key })
+        characters[record.id] = record
+      } catch {
+        // ignore malformed characters
+      }
+    }
   }
-  const hashed = hashPassword(password);
-  if (account.passwordHash && account.passwordHash !== hashed) {
-    return false;
-  }
-  if (!account.passwordHash && password) {
-    return false;
-  }
-  cache.activeAccountId = id;
-  account.updatedAt = Date.now();
-  persist();
-  return true;
+  return { id, characters, activeCharacterId, createdAt, updatedAt }
 }
 
-export function listCharacters(accountId: string): CharacterRecord[] {
-  const account = ensureAccount(accountId);
-  return Object.values(account.characters)
-    .map((character) => deepClone(character))
-    .sort((a, b) => {
-      const selA = a.lastSelectedAt ?? 0;
-      const selB = b.lastSelectedAt ?? 0;
-      if (selA !== selB) return selB - selA;
-      return b.updatedAt - a.updatedAt;
-    });
+function sanitizeAccountSummary(input: any): AccountSummary | undefined {
+  const id = typeof input?.id === 'string' ? input.id.trim() : ''
+  if (!id) {
+    return undefined
+  }
+  const createdAt = Number.isFinite(Number(input?.createdAt)) ? Number(input.createdAt) : Date.now()
+  const updatedAt = Number.isFinite(Number(input?.updatedAt)) ? Number(input?.updatedAt) : createdAt
+  const characterCount = Number.isFinite(Number(input?.characterCount))
+    ? Number(input.characterCount)
+    : 0
+  const activeCharacterId =
+    typeof input?.activeCharacterId === 'string' && input.activeCharacterId
+      ? input.activeCharacterId
+      : undefined
+  return { id, characterCount, activeCharacterId, createdAt, updatedAt }
 }
 
-export function upsertCharacter(
+let activeSelection: ActiveSelection = {}
+let activeCharacter: CharacterRecord | undefined
+
+export async function listAccounts(): Promise<AccountSummary[]> {
+  const response = await listAccountsRequest()
+  if (!Array.isArray(response)) {
+    return []
+  }
+  const summaries: AccountSummary[] = []
+  for (const entry of response) {
+    const summary = sanitizeAccountSummary(entry)
+    if (summary) {
+      summaries.push(summary)
+    }
+  }
+  return summaries.sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id))
+}
+
+export async function createAccount(accountId: string, password: string): Promise<AccountRecord> {
+  const id = String(accountId ?? '').trim()
+  if (!id) {
+    throw new Error('Account ID is required.')
+  }
+  const response = await createAccountRequest(id, password)
+  const account = sanitizeAccountRecord(response)
+  activeSelection = { accountId: account.id }
+  activeCharacter = undefined
+  return deepClone(account)
+}
+
+export async function authenticateAccount(accountId: string, password: string): Promise<boolean> {
+  const id = String(accountId ?? '').trim()
+  if (!id) {
+    return false
+  }
+  try {
+    const response = await authenticateAccountRequest(id, password)
+    if (response?.success) {
+      activeSelection = { accountId: id }
+      activeCharacter = undefined
+      return true
+    }
+    return false
+  } catch (error) {
+    console.error('Failed to authenticate account', error)
+    return false
+  }
+}
+
+export async function listCharacters(accountId: string): Promise<CharacterRecord[]> {
+  const id = String(accountId ?? '').trim()
+  if (!id) {
+    throw new Error('Account ID is required.')
+  }
+  const response = await listCharactersRequest(id)
+  if (!Array.isArray(response)) {
+    return []
+  }
+  const characters: CharacterRecord[] = []
+  for (const entry of response) {
+    try {
+      characters.push(sanitizeCharacterRecord(entry))
+    } catch {
+      // ignore invalid entries
+    }
+  }
+  characters.sort((a, b) => {
+    const selA = a.lastSelectedAt ?? 0
+    const selB = b.lastSelectedAt ?? 0
+    if (selA !== selB) return selB - selA
+    return b.updatedAt - a.updatedAt
+  })
+  return characters.map((character) => deepClone(character))
+}
+
+export async function upsertCharacter(
   accountId: string,
   data: { id?: string; profile: PlayerProfile; world: WorldState },
-): CharacterRecord {
-  const account = ensureAccount(accountId);
-  const id = data.id ? String(data.id).trim() : generateCharacterId(account);
+): Promise<CharacterRecord> {
+  const id = String(accountId ?? '').trim()
   if (!id) {
-    throw new Error('Character ID is required.');
+    throw new Error('Account ID is required.')
   }
-  const now = Date.now();
-  const record: CharacterRecord = {
-    id,
+  const payload = {
+    id: data.id ? String(data.id).trim() || undefined : undefined,
     profile: sanitizeProfile(data.profile),
     world: sanitizeWorld(data.world),
-    createdAt: account.characters[id]?.createdAt ?? now,
-    updatedAt: now,
-    lastSelectedAt: account.characters[id]?.lastSelectedAt,
-  };
-  account.characters[id] = record;
-  account.updatedAt = now;
-  persist();
-  return deepClone(record);
+  }
+  const response = await upsertCharacterRequest(id, payload)
+  const record = sanitizeCharacterRecord(response)
+  if (activeSelection.accountId === id && activeSelection.characterId === record.id) {
+    activeCharacter = record
+  }
+  return deepClone(record)
 }
 
-export function selectActiveCharacter(accountId: string | null, characterId?: string | null): ActiveSelection {
+export async function selectActiveCharacter(
+  accountId: string | null,
+  characterId?: string | null,
+): Promise<ActiveSelection> {
   if (!accountId) {
-    cache.activeAccountId = undefined;
-    persist();
-    return {};
+    activeSelection = {}
+    activeCharacter = undefined
+    return {}
   }
-  const account = ensureAccount(accountId);
-  let activeCharacterId: string | undefined;
-  if (characterId) {
-    const id = String(characterId).trim();
-    if (!id || !account.characters[id]) {
-      throw new Error('Character does not exist.');
-    }
-    account.characters[id].lastSelectedAt = Date.now();
-    activeCharacterId = id;
+  const id = String(accountId ?? '').trim()
+  if (!id) {
+    activeSelection = {}
+    activeCharacter = undefined
+    return {}
+  }
+  const character = characterId ? String(characterId).trim() : ''
+  await selectActiveCharacterRequest(id, character || null)
+  if (character) {
+    const response = await getCharacterRequest(id, character)
+    const record = sanitizeCharacterRecord(response)
+    activeSelection = { accountId: id, characterId: record.id }
+    activeCharacter = record
   } else {
-    activeCharacterId = undefined;
+    activeSelection = { accountId: id }
+    activeCharacter = undefined
   }
-  account.activeCharacterId = activeCharacterId;
-  cache.activeAccountId = account.id;
-  persist();
-  return getActiveSelection();
+  return { ...activeSelection }
 }
 
 export function getActiveSelection(): ActiveSelection {
-  const account = getActiveAccount();
-  if (!account) {
-    return {};
-  }
-  return { accountId: account.id, characterId: account.activeCharacterId };
+  return { ...activeSelection }
 }
 
 export function getActiveProfile(): PlayerProfile | undefined {
-  const record = getActiveCharacterRecord();
-  return record ? deepClone(record.profile) : undefined;
+  return activeCharacter ? deepClone(activeCharacter.profile) : undefined
 }
 
 export function getActiveWorld(): WorldState | undefined {
-  const record = getActiveCharacterRecord();
-  return record ? deepClone(record.world) : undefined;
+  return activeCharacter ? deepClone(activeCharacter.world) : undefined
 }
 
 export function getProfile(): PlayerProfile | undefined {
-  return getActiveProfile();
+  return getActiveProfile()
 }
 
 export function getWorld(): WorldState {
-  const world = getActiveWorld();
-  return world ? world : defaultWorld();
+  const world = getActiveWorld()
+  return world ? world : defaultWorld()
 }
 
-export function saveActiveCharacter(profile: PlayerProfile, world: WorldState) {
-  const selection = getActiveSelection();
+export async function saveActiveCharacter(profile: PlayerProfile, world: WorldState) {
+  const selection = getActiveSelection()
   if (!selection.accountId || !selection.characterId) {
-    return;
+    return
   }
-  const account = ensureAccount(selection.accountId);
-  const existing = account.characters[selection.characterId];
-  const now = Date.now();
-  const record: CharacterRecord = {
+  const record = await upsertCharacter(selection.accountId, {
     id: selection.characterId,
-    profile: sanitizeProfile(profile),
-    world: sanitizeWorld(world),
-    createdAt: existing?.createdAt ?? now,
-    updatedAt: now,
-    lastSelectedAt: now,
-  };
-  account.characters[selection.characterId] = record;
-  account.activeCharacterId = selection.characterId;
-  account.updatedAt = now;
-  persist();
+    profile,
+    world,
+  })
+  activeCharacter = record
 }
 
-export function saveAll(profile: PlayerProfile | undefined, world: WorldState) {
+export async function saveAll(profile: PlayerProfile | undefined, world: WorldState) {
   if (!profile) {
-    return;
+    return
   }
-  saveActiveCharacter(profile, world);
+  await saveActiveCharacter(profile, world)
 }
 
 export function resetSave() {
-  cache = defaultSave();
-  persist();
+  activeSelection = {}
+  activeCharacter = undefined
 }
 
 export function mergeInventoryEntry(inventory: InventoryEntry[], entry: InventoryEntry) {
-  if (!entry.id || !Number.isFinite(entry.qty)) return;
-  const existing = inventory.find((item) => item.id === entry.id);
+  if (!entry.id || !Number.isFinite(entry.qty)) return
+  const existing = inventory.find((item) => item.id === entry.id)
   if (existing) {
-    existing.qty += entry.qty;
+    existing.qty += entry.qty
   } else {
-    inventory.push({ id: entry.id, qty: entry.qty });
+    inventory.push({ id: entry.id, qty: entry.qty })
   }
   if (existing && existing.qty <= 0) {
-    const idx = inventory.indexOf(existing);
-    if (idx >= 0) inventory.splice(idx, 1);
+    const idx = inventory.indexOf(existing)
+    if (idx >= 0) inventory.splice(idx, 1)
   }
 }
 
 export function clampInventory(inventory: InventoryEntry[]) {
   for (let i = inventory.length - 1; i >= 0; i -= 1) {
     if (inventory[i].qty <= 0) {
-      inventory.splice(i, 1);
+      inventory.splice(i, 1)
     }
   }
 }


### PR DESCRIPTION
## Summary
- add new PostgreSQL tables and Express routes for accounts, characters, inventories, and world state with bcrypt-based authentication
- introduce a browser save client and refactor game save logic plus the auth flow to call backend APIs asynchronously
- update save tests to stub the API client and install bcryptjs dependency

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9b010df4083249bfc11b8b29f8197