### PR TITLE
Add knight portrait preview during character creation

### DIFF
--- a/minmmo/src/app/auth/AuthApp.tsx
+++ b/minmmo/src/app/auth/AuthApp.tsx
@@ -21,6 +21,8 @@ interface AuthAppProps {
   onLogout(): void;
 }
 
+const KNIGHT_PORTRAIT_SRC = '/assets/Characters/Knight/Knight_Still.png';
+
 type ViewState =
   | 'landing'
   | 'signup'
@@ -149,6 +151,8 @@ export function AuthApp({ selection, isGameRunning, onSelectionChange, onStartGa
     }
     return entries;
   }, [config]);
+
+  const selectedClassSummary = useMemo(() => classSummaries.find((clazz) => clazz.id === charClass), [charClass, classSummaries]);
 
   useEffect(() => {
     if (selection.accountId && selection.characterId) {
@@ -359,10 +363,16 @@ export function AuthApp({ selection, isGameRunning, onSelectionChange, onStartGa
             </select>
           </label>
           {charClass && (
-            <div className="small">
-              <strong>Starting Stats:</strong> HP {classSummaries.find((clazz) => clazz.id === charClass)?.stats.maxHp ?? '-'} · STA{' '}
-              {classSummaries.find((clazz) => clazz.id === charClass)?.stats.maxSta ?? '-'} · MP{' '}
-              {classSummaries.find((clazz) => clazz.id === charClass)?.stats.maxMp ?? '-'}
+            <div className="class-preview">
+              {charClass === 'Knight' && (
+                <img className="class-preview__portrait" src={KNIGHT_PORTRAIT_SRC} alt="Knight class portrait" />
+              )}
+              <div className="class-preview__info">
+                <div className="small">
+                  <strong>Starting Stats:</strong> HP {selectedClassSummary?.stats.maxHp ?? '-'} · STA{' '}
+                  {selectedClassSummary?.stats.maxSta ?? '-'} · MP {selectedClassSummary?.stats.maxMp ?? '-'}
+                </div>
+              </div>
             </div>
           )}
           {charError && <div className="error">{charError}</div>}

--- a/minmmo/src/index.css
+++ b/minmmo/src/index.css
@@ -238,6 +238,32 @@ h3 {
   font-size: 14px;
 }
 
+.class-preview {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.class-preview__portrait {
+  width: 96px;
+  height: auto;
+  border-radius: 8px;
+  border: 1px solid #2a3160;
+  background: #0d1124;
+  padding: 4px;
+  image-rendering: pixelated;
+  flex: 0 0 auto;
+}
+
+.class-preview__info {
+  flex: 1 1 160px;
+  min-width: 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .error {
   color: #ff7675;
   font-size: 13px;


### PR DESCRIPTION
## Summary
- display the knight still portrait during character creation when the class is selected
- refactor the class preview section to reuse computed stats and keep layout responsive

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc659ad9b48324ad3bab6249735bb6