### PR TITLE
Fix knight idle orientation textures

### DIFF
--- a/minmmo/src/game/scenes/Overworld.ts
+++ b/minmmo/src/game/scenes/Overworld.ts
@@ -721,7 +721,9 @@ export class Overworld extends Phaser.Scene {
     const profile = getActiveProfile();
 
     if (profile?.clazz === "Knight") {
-      const display = this.add.sprite(spawn.x, spawn.y, KNIGHT_STILL_KEY, 0);
+      this.playerFacing = "south";
+      const textureKey = this.resolveKnightTextureKey(this.playerFacing) ?? KNIGHT_WALK_SOUTH_KEY;
+      const display = this.add.sprite(spawn.x, spawn.y, textureKey, 0);
       display.setDepth(PLAYER_DEPTH);
       display.setOrigin(0.5, 0.75);
       const player = this.matter.add.gameObject(display, {
@@ -737,7 +739,6 @@ export class Overworld extends Phaser.Scene {
       player.setIgnoreGravity(true);
       this.player = player;
       this.isKnightPlayer = true;
-      this.playerFacing = "south";
       this.setKnightIdleFrame();
     } else {
       const player = this.matter.add.sprite(spawn.x, spawn.y, PLAYER_TEXTURE_KEY, undefined, {
@@ -919,7 +920,8 @@ export class Overworld extends Phaser.Scene {
       return;
     }
     this.player.anims.stop();
-    this.player.setTexture(KNIGHT_STILL_KEY, 0);
+    const textureKey = this.resolveKnightTextureKey(this.playerFacing) ?? KNIGHT_WALK_SOUTH_KEY;
+    this.player.setTexture(textureKey, 0);
   }
 
   private updateKnightAnimation(moveX: number, moveY: number) {
@@ -956,6 +958,21 @@ export class Overworld extends Phaser.Scene {
         return KNIGHT_ANIM_WALK_EAST;
       case "west":
         return KNIGHT_ANIM_WALK_WEST;
+      default:
+        return undefined;
+    }
+  }
+
+  private resolveKnightTextureKey(direction: "north" | "south" | "east" | "west") {
+    switch (direction) {
+      case "north":
+        return KNIGHT_WALK_NORTH_KEY;
+      case "south":
+        return KNIGHT_WALK_SOUTH_KEY;
+      case "east":
+        return KNIGHT_WALK_EAST_KEY;
+      case "west":
+        return KNIGHT_WALK_WEST_KEY;
       default:
         return undefined;
     }

--- a/minmmo/tests/overworld.knight.test.ts
+++ b/minmmo/tests/overworld.knight.test.ts
@@ -1,0 +1,92 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+describe("Overworld knight idle frame selection", () => {
+  let Overworld: typeof import("@game/scenes/Overworld").Overworld;
+
+  beforeAll(async () => {
+    vi.doMock("phaser", () => {
+      class Vector2 {
+        x: number;
+        y: number;
+        constructor(x = 0, y = 0) {
+          this.x = x;
+          this.y = y;
+        }
+      }
+
+      class Scene {
+        public anims = { exists: vi.fn(), create: vi.fn(), generateFrameNumbers: vi.fn() };
+        public add = {} as Record<string, unknown>;
+        public matter = {} as Record<string, unknown>;
+        public events = { once: vi.fn(), on: vi.fn(), off: vi.fn() };
+        public scale = { on: vi.fn(), off: vi.fn() };
+        public cameras = { main: {} } as Record<string, unknown>;
+        public input = { keyboard: { addKeys: vi.fn(), addKey: vi.fn(), addCapture: vi.fn(), removeCapture: vi.fn() } };
+        constructor() {}
+      }
+
+      return {
+        default: {
+          Scene,
+          Math: {
+            Vector2,
+            Clamp: (value: number, min: number, max: number) => Math.min(Math.max(value, min), max),
+          },
+          Geom: { Polygon: class {} },
+          Input: {
+            Keyboard: {
+              KeyCodes: { W: 87, A: 65, S: 83, D: 68, ESC: 27 },
+              JustDown: () => false,
+            },
+          },
+          Physics: { Matter: { Sprite: class {}, Events: { CollisionStartEvent: class {} } } },
+          Tilemaps: { Tilemap: class {}, Tileset: class {}, TilemapLayer: class {} },
+          Cameras: { Scene2D: { Camera: class {} } },
+          GameObjects: { Rectangle: class {}, Arc: class {}, GameObject: class {} },
+          Scenes: { Events: { SHUTDOWN: "shutdown", DESTROY: "destroy" } },
+          Scale: { Events: { RESIZE: "resize" } },
+          Structs: { Size: class {} },
+          Types: { Tilemaps: { TiledObject: class {} }, Math: { Vector2Like: class {} } },
+        },
+      };
+    }, { virtual: true });
+    vi.doMock("phaser3spectorjs", () => ({}), { virtual: true });
+    const fakeContext = {
+      fillStyle: "",
+      fillRect: vi.fn(),
+      getImageData: vi.fn(() => ({ data: new Uint8ClampedArray([0, 0, 0, 0]) })),
+      putImageData: vi.fn(),
+      drawImage: vi.fn(),
+      clearRect: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(() => fakeContext as unknown as CanvasRenderingContext2D);
+    ({ Overworld } = await import("@game/scenes/Overworld"));
+  });
+
+  const directions = [
+    { facing: "north" as const, expectedTexture: "knight-walk-north" },
+    { facing: "south" as const, expectedTexture: "knight-walk-south" },
+    { facing: "east" as const, expectedTexture: "knight-walk-east" },
+    { facing: "west" as const, expectedTexture: "knight-walk-west" },
+  ];
+
+  for (const { facing, expectedTexture } of directions) {
+    it(`uses the ${facing} walk sheet when stopping`, () => {
+      const scene = new Overworld();
+      const stop = vi.fn();
+      const setTexture = vi.fn();
+      (scene as any).playerFacing = facing;
+      (scene as any).player = {
+        anims: { stop },
+        setTexture,
+      };
+
+      (scene as any).setKnightIdleFrame();
+
+      expect(stop).toHaveBeenCalledOnce();
+      expect(setTexture).toHaveBeenCalledWith(expectedTexture, 0);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- initialize the knight spawn sprite with the proper facing texture
- update the idle frame helper to keep the current directional sheet when animations stop
- add a vitest that verifies each facing maps to the correct walk sheet

## Testing
- npm test -- overworld.knight.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc684f26308324a8110a62f4035f69